### PR TITLE
fix slack notification

### DIFF
--- a/src/alert/notification_template.go
+++ b/src/alert/notification_template.go
@@ -23,18 +23,22 @@ func newslackWebhookConfig(channel string) (*slackWebhookConfig, error) {
 	return config, nil
 }
 
-func (t *slackWebhookConfig) GetPayload(alert *model.Alert) (string, error) {
+func (t *slackWebhookConfig) GetPayload(alert *model.Alert, projectName string) (string, error) {
 	now := time.Now().Unix()
 	text := "設定されたAlertに合致する結果を検知しました。"
 	attachments := []interface{}{
 		map[string]interface{}{
 			"color":      getColor(alert.Severity),
-			"title":      alert.AlertID,
+			"title":      projectName,
 			"title_link": t.NotificationAlertUrl,
 			"fields": []interface{}{
 				map[string]string{
 					"title": "Severity",
 					"value": alert.Severity,
+				},
+				map[string]string{
+					"title": "Description",
+					"value": alert.Description,
 				},
 			},
 			"footer": "Send from RISKEN",

--- a/src/alert/repository.go
+++ b/src/alert/repository.go
@@ -54,6 +54,7 @@ type alertRepository interface {
 	ListFindingTag(uint32, uint64) (*[]model.FindingTag, error)
 	ListEnabledAlertCondition(uint32, []uint32) (*[]model.AlertCondition, error)
 	ListDisabledAlertCondition(uint32, []uint32) (*[]model.AlertCondition, error)
+	GetProject(uint32) (*model.Project, error)
 }
 
 type alertDB struct {

--- a/src/alert/repository_analyze.go
+++ b/src/alert/repository_analyze.go
@@ -88,3 +88,11 @@ func (f *alertDB) ListDisabledAlertCondition(projectID uint32, alertConditionID 
 	}
 	return &data, nil
 }
+
+func (f *alertDB) GetProject(projectID uint32) (*model.Project, error) {
+	var data model.Project
+	if err := f.Slave.Where("project_id = ?", projectID).First(&data).Error; err != nil {
+		return nil, err
+	}
+	return &data, nil
+}

--- a/src/alert/service_alert_test.go
+++ b/src/alert/service_alert_test.go
@@ -1938,3 +1938,8 @@ func (m *mockAlertRepository) ListDisabledAlertCondition(uint32, []uint32) (*[]m
 	args := m.Called()
 	return args.Get(0).(*[]model.AlertCondition), args.Error(1)
 }
+
+func (m *mockAlertRepository) GetProject(uint32) (*model.Project, error) {
+	args := m.Called()
+	return args.Get(0).(*model.Project), args.Error(1)
+}

--- a/src/alert/service_analyze.go
+++ b/src/alert/service_analyze.go
@@ -284,7 +284,11 @@ func (f *alertService) NotificationAlert(alertCondition *model.AlertCondition, a
 		}
 		switch notification.Type {
 		case "slack":
-			err = sendSlackNotification(notification.NotifySetting, alert)
+			project, err := f.repository.GetProject(alert.ProjectID)
+			if err != nil {
+				return err
+			}
+			err = sendSlackNotification(notification.NotifySetting, alert, project)
 			if err != nil {
 				return err
 			}
@@ -368,7 +372,7 @@ func getHistoryType(alertID uint32) string {
 	return "updated"
 }
 
-func sendSlackNotification(notifySetting string, alert *model.Alert) error {
+func sendSlackNotification(notifySetting string, alert *model.Alert, project *model.Project) error {
 	var setting slackNotifySetting
 	if err := json.Unmarshal([]byte(notifySetting), &setting); err != nil {
 		return err
@@ -385,7 +389,8 @@ func sendSlackNotification(notifySetting string, alert *model.Alert) error {
 	if err != nil {
 		return err
 	}
-	payload, err := slackAlert.GetPayload(alert)
+
+	payload, err := slackAlert.GetPayload(alert, project.Name)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
slack通知にProject名とAlertのDescriptionを追加しました。また、通知の追加のためにProject取得処理を追加しました。