### PR TITLE
fix_select_master_db

### DIFF
--- a/src/finding/repository_finding.go
+++ b/src/finding/repository_finding.go
@@ -77,7 +77,7 @@ const selectGetFindingByDataSource = `select * from finding where project_id = ?
 
 func (f *findingDB) GetFindingByDataSource(projectID uint32, dataSource, dataSourceID string) (*model.Finding, error) {
 	var result model.Finding
-	if err := f.Slave.Raw(selectGetFindingByDataSource,
+	if err := f.Master.Raw(selectGetFindingByDataSource,
 		projectID, dataSource, dataSourceID).First(&result).Error; err != nil {
 		return nil, err
 	}
@@ -106,7 +106,7 @@ const selectGetResourceByName = `select * from resource where project_id = ? and
 
 func (f *findingDB) GetResourceByName(projectID uint32, resourceName string) (*model.Resource, error) {
 	var data model.Resource
-	if err := f.Slave.Raw(selectGetResourceByName, projectID, resourceName).First(&data).Error; err != nil {
+	if err := f.Master.Raw(selectGetResourceByName, projectID, resourceName).First(&data).Error; err != nil {
 		return nil, err
 	}
 	return &data, nil
@@ -177,7 +177,7 @@ const selectGetFindingTagByKey = `select * from finding_tag where project_id = ?
 
 func (f *findingDB) GetFindingTagByKey(projectID uint32, findingID uint64, tag string) (*model.FindingTag, error) {
 	var data model.FindingTag
-	if err := f.Slave.Raw(selectGetFindingTagByKey, projectID, findingID, tag).First(&data).Error; err != nil {
+	if err := f.Master.Raw(selectGetFindingTagByKey, projectID, findingID, tag).First(&data).Error; err != nil {
 		return nil, err
 	}
 	return &data, nil

--- a/src/finding/repository_resource.go
+++ b/src/finding/repository_resource.go
@@ -97,7 +97,7 @@ const selectGetResourceTagByKey = `select * from resource_tag where project_id =
 
 func (f *findingDB) GetResourceTagByKey(projectID uint32, resourceID uint64, tag string) (*model.ResourceTag, error) {
 	var data model.ResourceTag
-	if err := f.Slave.Raw(selectGetResourceTagByKey, projectID, resourceID, tag).First(&data).Error; err != nil {
+	if err := f.Master.Raw(selectGetResourceTagByKey, projectID, resourceID, tag).First(&data).Error; err != nil {
 		return nil, err
 	}
 	return &data, nil

--- a/src/iam/repository_policy.go
+++ b/src/iam/repository_policy.go
@@ -85,7 +85,7 @@ const selectGetPolicyByName = `select * from policy where project_id = ? and nam
 
 func (i *iamDB) GetPolicyByName(projectID uint32, name string) (*model.Policy, error) {
 	var data model.Policy
-	if err := i.Slave.Raw(selectGetPolicyByName, projectID, name).First(&data).Error; err != nil {
+	if err := i.Master.Raw(selectGetPolicyByName, projectID, name).First(&data).Error; err != nil {
 		return nil, err
 	}
 	return &data, nil
@@ -120,7 +120,7 @@ const selectGetRolePolicy = `select * from role_policy where project_id = ? and 
 
 func (i *iamDB) GetRolePolicy(projectID, roleID, policyID uint32) (*model.RolePolicy, error) {
 	var data model.RolePolicy
-	if err := i.Slave.Raw(selectGetRolePolicy, projectID, roleID, policyID).First(&data).Error; err != nil {
+	if err := i.Master.Raw(selectGetRolePolicy, projectID, roleID, policyID).First(&data).Error; err != nil {
 		return nil, err
 	}
 	return &data, nil

--- a/src/iam/repository_role.go
+++ b/src/iam/repository_role.go
@@ -40,7 +40,7 @@ const selectGetRoleByName = `select * from role where project_id = ? and name =?
 
 func (i *iamDB) GetRoleByName(projectID uint32, name string) (*model.Role, error) {
 	var data model.Role
-	if err := i.Slave.Raw(selectGetRoleByName, projectID, name).First(&data).Error; err != nil {
+	if err := i.Master.Raw(selectGetRoleByName, projectID, name).First(&data).Error; err != nil {
 		return nil, err
 	}
 	return &data, nil
@@ -73,7 +73,7 @@ const selectGetUserRole = `select * from user_role where project_id = ? and user
 
 func (i *iamDB) GetUserRole(projectID, userID, roleID uint32) (*model.UserRole, error) {
 	var data model.UserRole
-	if err := i.Slave.Raw(selectGetUserRole, projectID, userID, roleID).First(&data).Error; err != nil {
+	if err := i.Master.Raw(selectGetUserRole, projectID, userID, roleID).First(&data).Error; err != nil {
 		return nil, err
 	}
 	return &data, nil

--- a/src/iam/repository_user.go
+++ b/src/iam/repository_user.go
@@ -55,7 +55,7 @@ const selectGetUserBySub = `select * from user where sub = ?`
 
 func (i *iamDB) GetUserBySub(sub string) (*model.User, error) {
 	var data model.User
-	if err := i.Slave.Raw(selectGetUserBySub, sub).First(&data).Error; err != nil {
+	if err := i.Master.Raw(selectGetUserBySub, sub).First(&data).Error; err != nil {
 		return nil, err
 	}
 	return &data, nil

--- a/src/project/repository.go
+++ b/src/project/repository.go
@@ -97,7 +97,7 @@ const selectGetProjectByName = `select * from project where name = ?`
 
 func (p *projectDB) GetProjectByName(name string) (*model.Project, error) {
 	var data model.Project
-	if err := p.Slave.Raw(selectGetProjectByName, name).First(&data).Error; err != nil {
+	if err := p.Master.Raw(selectGetProjectByName, name).First(&data).Error; err != nil {
 		return nil, err
 	}
 	return &data, nil


### PR DESCRIPTION
RDBがMaster-Slave構成の場合、Mutation系のAPIでデータ登録後にすぐにselectしている箇所はSlaveではなくMasterのDB参照するように変更します。
レプリの遅延（0.2秒程度）の影響でAPIがエラーを返すケースが発生していたため。