### PR TITLE
fix alert message

### DIFF
--- a/src/alert/notification_template_test.go
+++ b/src/alert/notification_template_test.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/CyberAgent/mimosa-core/pkg/model"
+)
+
+/*
+ * Alert
+ */
+
+func TestGenerateRuleList(t *testing.T) {
+	cases := []struct {
+		name  string
+		input *[]model.AlertRule
+		want  string
+	}{
+		{
+			name: "1 line",
+			input: &[]model.AlertRule{
+				{AlertRuleID: 1, Name: "aaa"},
+			},
+			want: "- aaa",
+		},
+		{
+			name: "Multi lines",
+			input: &[]model.AlertRule{
+				{AlertRuleID: 1, Name: "aaa"},
+				{AlertRuleID: 2, Name: "bbb"},
+				{AlertRuleID: 3, Name: "ccc"},
+			},
+			want: "- aaa\n- bbb\n- ccc",
+		},
+		{
+			name:  "Nil input",
+			input: nil,
+			want:  "",
+		},
+		{
+			name: "Too many rules",
+			input: &[]model.AlertRule{
+				{AlertRuleID: 1, Name: "aaa"},
+				{AlertRuleID: 2, Name: "bbb"},
+				{AlertRuleID: 3, Name: "ccc"},
+				{AlertRuleID: 4, Name: "ddd"},
+				{AlertRuleID: 5, Name: "eee"},
+				{AlertRuleID: 6, Name: "fff"},
+				{AlertRuleID: 7, Name: "ggg"},
+				{AlertRuleID: 8, Name: "hhh"},
+				{AlertRuleID: 9, Name: "iii"},
+				{AlertRuleID: 10, Name: "jjj"},
+			},
+			want: "- aaa\n- bbb\n- ccc\n- ddd\n- eee\n- ...",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := generateRuleList(c.input)
+			if !reflect.DeepEqual(got, c.want) {
+				t.Fatalf("Unexpected result: want=%+v, got=%+v", c.want, got)
+			}
+		})
+	}
+}

--- a/src/alert/service_analyze_test.go
+++ b/src/alert/service_analyze_test.go
@@ -122,7 +122,7 @@ func TestSendSlackNotification(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			got := sendSlackNotification(c.notifySetting, c.alert, c.project)
+			got := sendSlackNotification(c.notifySetting, c.alert, c.project, &[]model.AlertRule{})
 			if (got != nil && !c.wantErr) || (got == nil && c.wantErr) {
 				t.Fatalf("Unexpected error: %+v", got)
 			}
@@ -237,7 +237,7 @@ func TestNotificationAlert(t *testing.T) {
 			mockDB.On("GetNotification").Return(c.mockGetNotification, c.mockGetNotificationErr).Once()
 			mockDB.On("UpsertAlertCondNotification").Return(c.mockUpsertAlertCondNotification, c.mockUpsertAlertCondNotificationErr).Once()
 			mockDB.On("GetProject").Return(c.mockGetProject, c.mockGetProjectErr).Once()
-			got := svc.NotificationAlert(context.Background(), c.alertCondition, c.alert)
+			got := svc.NotificationAlert(context.Background(), c.alertCondition, c.alert, &[]model.AlertRule{})
 			if (got != nil && !c.wantErr) || (got == nil && c.wantErr) {
 				t.Fatalf("Unexpected error: %+v", got)
 			}


### PR DESCRIPTION
アラートのSlack通知で紐付いているルール名を出すようにします。
ルールは複数紐付けられるので通知時は最大５件まで表示するように制御しています
![image](https://user-images.githubusercontent.com/25426601/125732300-99073909-97b9-499d-b09f-753457f5a607.png)

Feedback: 
https://github.com/CyberAgent/risken-community/issues/38
