### PR TITLE
Remove direct operation to finding table and unused interface

### DIFF
--- a/src/alert/repository.go
+++ b/src/alert/repository.go
@@ -51,7 +51,6 @@ type alertRepository interface {
 	ListNotificationByAlertConditionID(context.Context, uint32, uint32) (*[]model.Notification, error)
 	DeactivateAlert(context.Context, *model.Alert) error
 	GetAlertByAlertConditionIDStatus(context.Context, uint32, uint32, []string) (*model.Alert, error)
-	ListFinding(context.Context, uint32) (*[]model.Finding, error)
 	ListFindingTag(context.Context, uint32, uint64) (*[]model.FindingTag, error)
 	ListEnabledAlertCondition(context.Context, uint32, []uint32) (*[]model.AlertCondition, error)
 	ListDisabledAlertCondition(context.Context, uint32, []uint32) (*[]model.AlertCondition, error)

--- a/src/alert/repository_analyze.go
+++ b/src/alert/repository_analyze.go
@@ -44,24 +44,6 @@ func (a *alertDB) GetAlertByAlertConditionIDStatus(ctx context.Context, projectI
 	return &data, nil
 }
 
-const selectListFinding string = `
-select
-  * 
-from
-  finding f 
-where
-  f.project_id = ?
-  and not exists(select * from pend_finding pf where pf.finding_id=f.finding_id)
-`
-
-func (a *alertDB) ListFinding(ctx context.Context, projectID uint32) (*[]model.Finding, error) {
-	var data []model.Finding
-	if err := a.Slave.WithContext(ctx).Raw(selectListFinding, projectID).Find(&data).Error; err != nil {
-		return nil, err
-	}
-	return &data, nil
-}
-
 func (a *alertDB) ListFindingTag(ctx context.Context, projectID uint32, findingID uint64) (*[]model.FindingTag, error) {
 	var data []model.FindingTag
 	if err := a.Slave.WithContext(ctx).Where("project_id = ? AND finding_id = ?", projectID, findingID).Find(&data).Error; err != nil {


### PR DESCRIPTION
alertサービスがfindingテーブルを直接参照しないようにした
参照していた関数は、使用されていないインタフェースの実装だったので合わせて削除してます