### PR TITLE
fix: DB param(conn_max_life_time)

### DIFF
--- a/src/finding/repository.go
+++ b/src/finding/repository.go
@@ -124,7 +124,7 @@ func initDB(isMaster bool) *gorm.DB {
 		appLogger.Fatalf("Failed to get generic database object(sql.DB). isMaster: %t, err: %+v", isMaster, err)
 	}
 	sqlDB.SetMaxOpenConns(conf.MaxConnection)
-	sqlDB.SetConnMaxLifetime(time.Duration(conf.MaxConnection) * time.Second)
+	sqlDB.SetConnMaxLifetime(time.Duration(conf.MaxConnection/2) * time.Second)
 	appLogger.Infof("Connected to Database. isMaster: %t", isMaster)
 	return db
 }


### PR DESCRIPTION
https://github.com/ca-risken/internal-community/issues/107
の対応で、改善は見られたものの invalid connectionがまだ発生しているため、conn_max_life_timeの値をもう少し短くします