### PR TITLE
fix: recommend transaction

### DIFF
--- a/src/finding/service_recommend.go
+++ b/src/finding/service_recommend.go
@@ -45,7 +45,7 @@ func (f *findingService) PutRecommend(ctx context.Context, req *finding.PutRecom
 		return nil, err
 	}
 	// exists finding in the req project
-	if f, err := f.repository.GetFinding(ctx, req.ProjectId, req.FindingId, false); err != nil || zero.IsZeroVal(f.FindingID) {
+	if f, err := f.repository.GetFinding(ctx, req.ProjectId, req.FindingId, true); err != nil || zero.IsZeroVal(f.FindingID) {
 		appLogger.Warnf("Failed to get finding, project_id=%d, finding_id=%d, err=%+v", req.ProjectId, req.FindingId, err)
 		return nil, err
 	}


### PR DESCRIPTION
レコメンド登録で分散トランザクションの問題が発生していたので修正します
（レコメンド登録時にチェックしてるFindingデータの参照先をslaveではなくmasterのDBに変更）