### PR TITLE
Fix-alert

### DIFF
--- a/pkg/server/alert/alert_condition.go
+++ b/pkg/server/alert/alert_condition.go
@@ -87,7 +87,25 @@ func (a *AlertService) DeleteAlertCondition(ctx context.Context, req *alert.Dele
 	if err := req.Validate(); err != nil {
 		return nil, err
 	}
-	err := a.repository.DeleteAlertCondition(ctx, req.ProjectId, req.AlertConditionId)
+	alertCondRules, err := a.repository.ListAlertCondRule(ctx, req.ProjectId, req.AlertConditionId, 0, 0, time.Now().Unix())
+	if err != nil {
+		return nil, err
+	}
+	for _, acr := range *alertCondRules {
+		if err = a.repository.DeleteAlertCondRule(ctx, acr.ProjectID, acr.AlertConditionID, acr.AlertRuleID); err != nil {
+			return nil, err
+		}
+	}
+	alertCondNotifications, err := a.repository.ListAlertCondNotification(ctx, req.ProjectId, req.AlertConditionId, 0, 0, time.Now().Unix())
+	if err != nil {
+		return nil, err
+	}
+	for _, acn := range *alertCondNotifications {
+		if err = a.repository.DeleteAlertCondNotification(ctx, acn.ProjectID, acn.AlertConditionID, acn.NotificationID); err != nil {
+			return nil, err
+		}
+	}
+	err = a.repository.DeleteAlertCondition(ctx, req.ProjectId, req.AlertConditionId)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/server/alert/alert_condition.go
+++ b/pkg/server/alert/alert_condition.go
@@ -176,7 +176,17 @@ func (a *AlertService) DeleteAlertRule(ctx context.Context, req *alert.DeleteAle
 	if err := req.Validate(); err != nil {
 		return nil, err
 	}
-	err := a.repository.DeleteAlertRule(ctx, req.ProjectId, req.AlertRuleId)
+
+	alertRules, err := a.repository.ListAlertCondRule(ctx, req.ProjectId, 0, req.AlertRuleId, 0, time.Now().Unix())
+	if err != nil {
+		return nil, err
+	}
+	for _, ar := range *alertRules {
+		if err = a.repository.DeleteAlertCondRule(ctx, ar.ProjectID, ar.AlertConditionID, ar.AlertRuleID); err != nil {
+			return nil, err
+		}
+	}
+	err = a.repository.DeleteAlertRule(ctx, req.ProjectId, req.AlertRuleId)
 	if err != nil {
 		return nil, err
 	}
@@ -390,7 +400,18 @@ func (a *AlertService) DeleteNotification(ctx context.Context, req *alert.Delete
 	if err := req.Validate(); err != nil {
 		return nil, err
 	}
-	err := a.repository.DeleteNotification(ctx, req.ProjectId, req.NotificationId)
+
+	notifications, err := a.repository.ListAlertCondNotification(ctx, req.ProjectId, 0, req.NotificationId, 0, time.Now().Unix())
+	if err != nil {
+		return nil, err
+	}
+	for _, n := range *notifications {
+		if err = a.repository.DeleteAlertCondNotification(ctx, n.ProjectID, n.AlertConditionID, n.NotificationID); err != nil {
+			return nil, err
+		}
+	}
+
+	err = a.repository.DeleteNotification(ctx, req.ProjectId, req.NotificationId)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/server/alert/alert_test.go
+++ b/pkg/server/alert/alert_test.go
@@ -898,6 +898,10 @@ func TestDeleteAlertCondition(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
+			mockDB.On("ListAlertCondRule").Return(&[]model.AlertCondRule{{AlertConditionID: 1}}, nil)
+			mockDB.On("DeleteAlertCondRule").Return(c.mockErr).Once()
+			mockDB.On("ListAlertCondNotification").Return(&[]model.AlertCondNotification{{AlertConditionID: 1}}, nil)
+			mockDB.On("DeleteAlertCondNotification").Return(c.mockErr).Once()
 			mockDB.On("DeleteAlertCondition").Return(c.mockErr).Once()
 			_, err := svc.DeleteAlertCondition(ctx, c.input)
 			if err != nil && !c.wantErr {

--- a/pkg/server/alert/alert_test.go
+++ b/pkg/server/alert/alert_test.go
@@ -8,8 +8,8 @@ import (
 	"time"
 
 	"github.com/ca-risken/core/pkg/db/mocks"
-	"github.com/ca-risken/core/proto/alert"
 	"github.com/ca-risken/core/pkg/model"
+	"github.com/ca-risken/core/proto/alert"
 	"gorm.io/gorm"
 )
 
@@ -1118,6 +1118,8 @@ func TestDeleteAlertRule(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
+			mockDB.On("ListAlertCondRule").Return(&[]model.AlertCondRule{{AlertConditionID: 1}}, nil)
+			mockDB.On("DeleteAlertCondRule").Return(nil)
 			mockDB.On("DeleteAlertRule").Return(c.mockErr).Once()
 			_, err := svc.DeleteAlertRule(ctx, c.input)
 			if err != nil && !c.wantErr {
@@ -1618,6 +1620,8 @@ func TestDeleteNotification(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
+			mockDB.On("ListAlertCondNotification").Return(&[]model.AlertCondNotification{{ProjectID: 1, AlertConditionID: 1, NotificationID: 1}}, nil)
+			mockDB.On("DeleteAlertCondNotification").Return(nil)
 			mockDB.On("DeleteNotification").Return(c.mockErr).Once()
 			_, err := svc.DeleteNotification(ctx, c.input)
 			if err != nil && !c.wantErr {


### PR DESCRIPTION
alert_condition関連の削除時にデータベースの不整合が発生していたため、以下の対策を行います。
- notification削除時にalert_cond_notificationを削除
- alert_rule削除時にalert_cond_ruleを削除
- alert_condition削除時にalert_cond_rule,alert_cond_notificationを削除