### PR TITLE
DRY logger

### DIFF
--- a/pkg/server/finding/finding.go
+++ b/pkg/server/finding/finding.go
@@ -289,7 +289,8 @@ func (f *FindingService) ClearScore(ctx context.Context, req *finding.ClearScore
 	if err != nil {
 		return nil, err
 	}
-	appLogger.Infof(ctx, "Finding score cleared, param=%+v", req)
+	f.logger.Infof(ctx, "Finding score cleared, param=%+v", req)
+
 	return &empty.Empty{}, nil
 }
 

--- a/pkg/server/finding/finding_batch.go
+++ b/pkg/server/finding/finding_batch.go
@@ -162,7 +162,8 @@ func (f *FindingService) PutFindingBatch(ctx context.Context, req *finding.PutFi
 	if err := f.repository.BulkUpsertResourceTag(ctx, resourceTags); err != nil {
 		return nil, fmt.Errorf("Failed to BulkUpsertResourceTag, err=%+w", err)
 	}
-	appLogger.Infof(ctx, "Succeded PutFindingBatch, project_id=%d, findings=%d", req.ProjectId, len(req.Finding))
+	f.logger.Infof(ctx, "Succeded PutFindingBatch, project_id=%d, findings=%d", req.ProjectId, len(req.Finding))
+
 	return &empty.Empty{}, nil
 }
 
@@ -223,6 +224,7 @@ func (f *FindingService) PutResourceBatch(ctx context.Context, req *finding.PutR
 	if err := f.repository.BulkUpsertResourceTag(ctx, resourceTags); err != nil {
 		return nil, fmt.Errorf("Failed to BulkUpsertResourceTag, err=%+w", err)
 	}
-	appLogger.Infof(ctx, "Succeded PutResourceBatch, project_id=%d, resources=%d", req.ProjectId, len(req.Resource))
+	f.logger.Infof(ctx, "Succeded PutResourceBatch, project_id=%d, resources=%d", req.ProjectId, len(req.Resource))
+
 	return &empty.Empty{}, nil
 }

--- a/pkg/server/finding/finding_batch_test.go
+++ b/pkg/server/finding/finding_batch_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/ca-risken/common/pkg/logging"
 	"github.com/ca-risken/core/pkg/db/mocks"
 	"github.com/ca-risken/core/pkg/model"
 	"github.com/ca-risken/core/proto/finding"
@@ -13,7 +14,7 @@ import (
 func TestPutFindingBatch(t *testing.T) {
 	var ctx context.Context
 	mockDB := mocks.MockFindingRepository{}
-	svc := FindingService{repository: &mockDB}
+	svc := FindingService{repository: &mockDB, logger: logging.NewLogger()}
 	type mockResp struct {
 		GetFindingByDataSourceCall bool
 		GetFindingByDataSourceResp *model.Finding
@@ -195,7 +196,7 @@ func TestPutFindingBatch(t *testing.T) {
 func TestPutResourceBatch(t *testing.T) {
 	var ctx context.Context
 	mockDB := mocks.MockFindingRepository{}
-	svc := FindingService{repository: &mockDB}
+	svc := FindingService{repository: &mockDB, logger: logging.NewLogger()}
 	type mockResp struct {
 		GetResourceByNameCall bool
 		GetResourceByNameResp *model.Resource

--- a/pkg/server/finding/finding_setting.go
+++ b/pkg/server/finding/finding_setting.go
@@ -125,7 +125,7 @@ func (f *FindingService) getFindingSettingByResource(ctx context.Context, projec
 	}
 	var setting findingSetting
 	if err := json.Unmarshal([]byte(fs.Setting), &setting); err != nil {
-		appLogger.Warnf(ctx, "Failed to unmarshal finding setting JSON, projectID=%d, resourceName=%s, err=%+v", projectID, resourceName, err)
+		f.logger.Warnf(ctx, "Failed to unmarshal finding setting JSON, projectID=%d, resourceName=%s, err=%+v", projectID, resourceName, err)
 		return &findingSetting{}, nil
 	}
 	return &setting, nil

--- a/pkg/server/finding/finding_test.go
+++ b/pkg/server/finding/finding_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ca-risken/common/pkg/logging"
 	"github.com/ca-risken/core/pkg/db"
 	"github.com/ca-risken/core/pkg/db/mocks"
 	"github.com/ca-risken/core/pkg/model"
@@ -525,7 +526,7 @@ func TestTagFinding(t *testing.T) {
 func TestClearSocre(t *testing.T) {
 	var ctx context.Context
 	mockDB := mocks.MockFindingRepository{}
-	svc := FindingService{repository: &mockDB}
+	svc := FindingService{repository: &mockDB, logger: logging.NewLogger()}
 	cases := []struct {
 		name     string
 		input    *finding.ClearScoreRequest

--- a/pkg/server/finding/logger.go
+++ b/pkg/server/finding/logger.go
@@ -1,5 +1,0 @@
-package finding
-
-import "github.com/ca-risken/common/pkg/logging"
-
-var appLogger = logging.NewLogger()

--- a/pkg/server/finding/pend.go
+++ b/pkg/server/finding/pend.go
@@ -31,7 +31,7 @@ func (f *FindingService) PutPendFinding(ctx context.Context, req *finding.PutPen
 	_, err := f.repository.GetFinding(ctx, req.ProjectId, req.PendFinding.FindingId, false)
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
-			appLogger.Warnf(ctx, "RecordNotFound for PutPendFinding API, project_id=%d, finding=%d", req.ProjectId, req.PendFinding.FindingId)
+			f.logger.Warnf(ctx, "RecordNotFound for PutPendFinding API, project_id=%d, finding=%d", req.ProjectId, req.PendFinding.FindingId)
 		}
 		return nil, err // DB error or RecordNotFound error
 	}

--- a/pkg/server/finding/pend_test.go
+++ b/pkg/server/finding/pend_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ca-risken/common/pkg/logging"
 	"github.com/ca-risken/core/pkg/db/mocks"
 	"github.com/ca-risken/core/pkg/model"
 	"github.com/ca-risken/core/proto/finding"
@@ -57,7 +58,7 @@ func TestPutPendFinding(t *testing.T) {
 	var ctx context.Context
 	now := time.Now()
 	mockDB := mocks.MockFindingRepository{}
-	svc := FindingService{repository: &mockDB}
+	svc := FindingService{repository: &mockDB, logger: logging.NewLogger()}
 	cases := []struct {
 		name         string
 		input        *finding.PutPendFindingRequest

--- a/pkg/server/finding/recommend.go
+++ b/pkg/server/finding/recommend.go
@@ -46,8 +46,8 @@ func (f *FindingService) PutRecommend(ctx context.Context, req *finding.PutRecom
 		return nil, err
 	}
 	// exists finding in the req project
-	if f, err := f.repository.GetFinding(ctx, req.ProjectId, req.FindingId, true); err != nil || zero.IsZeroVal(f.FindingID) {
-		appLogger.Warnf(ctx, "Failed to get finding, project_id=%d, finding_id=%d, err=%+v", req.ProjectId, req.FindingId, err)
+	if fd, err := f.repository.GetFinding(ctx, req.ProjectId, req.FindingId, true); err != nil || zero.IsZeroVal(fd.FindingID) {
+		f.logger.Warnf(ctx, "Failed to get finding, project_id=%d, finding_id=%d, err=%+v", req.ProjectId, req.FindingId, err)
 		return nil, err
 	}
 	registered, err := f.repository.UpsertRecommend(ctx, &model.Recommend{

--- a/pkg/server/finding/recommend_test.go
+++ b/pkg/server/finding/recommend_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ca-risken/common/pkg/logging"
 	"github.com/ca-risken/core/pkg/db/mocks"
 	"github.com/ca-risken/core/pkg/model"
 	"github.com/ca-risken/core/proto/finding"
@@ -69,7 +70,7 @@ func TestPutRecommend(t *testing.T) {
 	var ctx context.Context
 	now := time.Now()
 	mockDB := mocks.MockFindingRepository{}
-	svc := FindingService{repository: &mockDB}
+	svc := FindingService{repository: &mockDB, logger: logging.NewLogger()}
 	cases := []struct {
 		name    string
 		input   *finding.PutRecommendRequest

--- a/pkg/server/finding/service.go
+++ b/pkg/server/finding/service.go
@@ -1,6 +1,9 @@
 package finding
 
-import "github.com/ca-risken/core/pkg/db"
+import (
+	"github.com/ca-risken/common/pkg/logging"
+	"github.com/ca-risken/core/pkg/db"
+)
 
 const (
 	defaultSortDirection string = "asc"
@@ -9,11 +12,13 @@ const (
 
 type FindingService struct {
 	repository db.FindingRepository
+	logger     logging.Logger
 }
 
-func NewFindingService(repository db.FindingRepository) *FindingService {
+func NewFindingService(repository db.FindingRepository, logger logging.Logger) *FindingService {
 	return &FindingService{
 		repository: repository,
+		logger:     logger,
 	}
 }
 

--- a/pkg/server/iam/access_token.go
+++ b/pkg/server/iam/access_token.go
@@ -179,7 +179,7 @@ func (i *IAMService) AnalyzeTokenExpiration(ctx context.Context, _ *empty.Empty)
 		token.TokenHash = "xxx" // mask credentials
 		buf, err := json.Marshal(token)
 		if err != nil {
-			appLogger.Errorf(ctx, "Failed to encoding json, accessToken=%+v, err=%+v", token, err)
+			i.logger.Errorf(ctx, "Failed to encoding json, accessToken=%+v, err=%+v", token, err)
 			return nil, err
 		}
 		resp, err := i.findingClient.PutFinding(ctx, &finding.PutFindingRequest{

--- a/pkg/server/iam/auth.go
+++ b/pkg/server/iam/auth.go
@@ -27,7 +27,7 @@ func (i *IAMService) IsAuthorized(ctx context.Context, req *iam.IsAuthorizedRequ
 		return &iam.IsAuthorizedResponse{Ok: false}, err
 	}
 	if isAuthorized {
-		appLogger.Infof(ctx, "Authorized user action, request=%+v", req)
+		i.logger.Infof(ctx, "Authorized user action, request=%+v", req)
 	}
 	return &iam.IsAuthorizedResponse{Ok: isAuthorized}, nil
 }
@@ -48,7 +48,7 @@ func (i *IAMService) IsAuthorizedAdmin(ctx context.Context, req *iam.IsAuthorize
 		return &iam.IsAuthorizedAdminResponse{Ok: false}, err
 	}
 	if isAuthorized {
-		appLogger.Infof(ctx, "Authorized user action, request=%+v", req)
+		i.logger.Infof(ctx, "Authorized user action, request=%+v", req)
 	}
 	return &iam.IsAuthorizedAdminResponse{Ok: isAuthorized}, nil
 }
@@ -62,7 +62,7 @@ func (i *IAMService) IsAuthorizedToken(ctx context.Context, req *iam.IsAuthorize
 		return nil, err
 	}
 	if !existsMaintainer {
-		appLogger.Warnf(ctx, "Unautorized the token that has no maintainers or expired in the project. project_id=%d, access_token_id=%d", req.ProjectId, req.AccessTokenId)
+		i.logger.Warnf(ctx, "Unautorized the token that has no maintainers or expired in the project. project_id=%d, access_token_id=%d", req.ProjectId, req.AccessTokenId)
 		return &iam.IsAuthorizedTokenResponse{Ok: false}, nil
 	}
 	policies, err := i.repository.GetTokenPolicy(ctx, req.AccessTokenId)
@@ -77,7 +77,7 @@ func (i *IAMService) IsAuthorizedToken(ctx context.Context, req *iam.IsAuthorize
 		return &iam.IsAuthorizedTokenResponse{Ok: false}, err
 	}
 	if isAuthorized {
-		appLogger.Infof(ctx, "Authorized access_token action, request=%+v", req)
+		i.logger.Infof(ctx, "Authorized access_token action, request=%+v", req)
 	}
 	return &iam.IsAuthorizedTokenResponse{Ok: isAuthorized}, nil
 }
@@ -118,6 +118,7 @@ func (i *IAMService) IsAdmin(ctx context.Context, req *iam.IsAdminRequest) (*iam
 	if policy == nil || len(*policy) < 1 {
 		return &iam.IsAdminResponse{Ok: false}, nil
 	}
-	appLogger.Debugf(ctx, "user(%d) is admin, policies: %d", req.UserId, len(*policy))
+	i.logger.Debugf(ctx, "user(%d) is admin, policies: %d", req.UserId, len(*policy))
+
 	return &iam.IsAdminResponse{Ok: true}, nil
 }

--- a/pkg/server/iam/auth_test.go
+++ b/pkg/server/iam/auth_test.go
@@ -5,6 +5,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/ca-risken/common/pkg/logging"
 	"github.com/ca-risken/core/pkg/db/mocks"
 	"github.com/ca-risken/core/pkg/model"
 	"github.com/ca-risken/core/proto/iam"
@@ -14,7 +15,7 @@ import (
 func TestIsAuthorized(t *testing.T) {
 	var ctx context.Context
 	mock := mocks.MockIAMRepository{}
-	svc := IAMService{repository: &mock}
+	svc := IAMService{repository: &mock, logger: logging.NewLogger()}
 	cases := []struct {
 		name         string
 		input        *iam.IsAuthorizedRequest
@@ -69,7 +70,7 @@ func TestIsAuthorized(t *testing.T) {
 func TestIsAuthorizedAdmin(t *testing.T) {
 	var ctx context.Context
 	mock := mocks.MockIAMRepository{}
-	svc := IAMService{repository: &mock}
+	svc := IAMService{repository: &mock, logger: logging.NewLogger()}
 	cases := []struct {
 		name         string
 		input        *iam.IsAuthorizedAdminRequest
@@ -124,7 +125,7 @@ func TestIsAuthorizedAdmin(t *testing.T) {
 func TestIsAuthorizedToken(t *testing.T) {
 	var ctx context.Context
 	mock := mocks.MockIAMRepository{}
-	svc := IAMService{repository: &mock}
+	svc := IAMService{repository: &mock, logger: logging.NewLogger()}
 	cases := []struct {
 		name    string
 		input   *iam.IsAuthorizedTokenRequest
@@ -308,7 +309,7 @@ func TestIsAuthorizedByPolicy(t *testing.T) {
 func TestIsAdmin(t *testing.T) {
 	var ctx context.Context
 	mock := mocks.MockIAMRepository{}
-	svc := IAMService{repository: &mock}
+	svc := IAMService{repository: &mock, logger: logging.NewLogger()}
 	cases := []struct {
 		name         string
 		input        *iam.IsAdminRequest

--- a/pkg/server/iam/logger.go
+++ b/pkg/server/iam/logger.go
@@ -1,5 +1,0 @@
-package iam
-
-import "github.com/ca-risken/common/pkg/logging"
-
-var appLogger = logging.NewLogger()

--- a/pkg/server/iam/service.go
+++ b/pkg/server/iam/service.go
@@ -1,6 +1,7 @@
 package iam
 
 import (
+	"github.com/ca-risken/common/pkg/logging"
 	"github.com/ca-risken/core/pkg/db"
 	"github.com/ca-risken/core/proto/finding"
 )
@@ -8,11 +9,13 @@ import (
 type IAMService struct {
 	repository    db.IAMRepository
 	findingClient finding.FindingServiceClient
+	logger        logging.Logger
 }
 
-func NewIAMService(repository db.IAMRepository, findingClient finding.FindingServiceClient) *IAMService {
+func NewIAMService(repository db.IAMRepository, findingClient finding.FindingServiceClient, logger logging.Logger) *IAMService {
 	return &IAMService{
 		repository:    repository,
 		findingClient: findingClient,
+		logger:        logger,
 	}
 }

--- a/pkg/server/iam/user.go
+++ b/pkg/server/iam/user.go
@@ -34,7 +34,7 @@ func (i *IAMService) GetUser(ctx context.Context, req *iam.GetUserRequest) (*iam
 	user, err := i.repository.GetUser(ctx, req.UserId, req.Sub)
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
-			appLogger.Infof(ctx, "[GetUser]User not found: GetUserRequest=%+v", req)
+			i.logger.Infof(ctx, "[GetUser]User not found: GetUserRequest=%+v", req)
 			return &iam.GetUserResponse{}, nil
 		}
 		return nil, err
@@ -60,7 +60,7 @@ func (i *IAMService) PutUser(ctx context.Context, req *iam.PutUserRequest) (*iam
 		}
 		isFisrstUser = users == nil || *users == 0
 	}
-	appLogger.Debugf(ctx, "isFisrstUser: %t", isFisrstUser)
+	i.logger.Debugf(ctx, "isFisrstUser: %t", isFisrstUser)
 
 	// PKが登録済みの場合は取得した値をセット。未登録はゼロ値のママでAutoIncrementさせる（更新の都度、無駄にAutoIncrementさせないように）
 	var userID uint32
@@ -85,7 +85,7 @@ func (i *IAMService) PutUser(ctx context.Context, req *iam.PutUserRequest) (*iam
 		if err := i.repository.AttachAllAdminRole(ctx, registerdData.UserID); err != nil {
 			return nil, err
 		}
-		appLogger.Infof(ctx, "Attach admin role for first user, user_id=%d", registerdData.UserID)
+		i.logger.Infof(ctx, "Attach admin role for first user, user_id=%d", registerdData.UserID)
 	}
 	return &iam.PutUserResponse{User: convertUser(registerdData)}, nil
 }

--- a/pkg/server/iam/user_test.go
+++ b/pkg/server/iam/user_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ca-risken/common/pkg/logging"
 	"github.com/ca-risken/core/pkg/db/mocks"
 	"github.com/ca-risken/core/pkg/model"
 	"github.com/ca-risken/core/proto/iam"
@@ -72,7 +73,7 @@ func TestGetUser(t *testing.T) {
 	var ctx context.Context
 	now := time.Now()
 	mock := mocks.MockIAMRepository{}
-	svc := IAMService{repository: &mock}
+	svc := IAMService{repository: &mock, logger: logging.NewLogger()}
 	cases := []struct {
 		name         string
 		input        *iam.GetUserRequest
@@ -125,7 +126,7 @@ func TestPutUser(t *testing.T) {
 	var ctx context.Context
 	now := time.Now()
 	mock := mocks.MockIAMRepository{}
-	svc := IAMService{repository: &mock}
+	svc := IAMService{repository: &mock, logger: logging.NewLogger()}
 	cases := []struct {
 		name        string
 		input       *iam.PutUserRequest

--- a/pkg/server/project/logger.go
+++ b/pkg/server/project/logger.go
@@ -1,5 +1,0 @@
-package project
-
-import "github.com/ca-risken/common/pkg/logging"
-
-var appLogger = logging.NewLogger()

--- a/pkg/server/project/project.go
+++ b/pkg/server/project/project.go
@@ -24,8 +24,6 @@ func convertProjectWithTag(p *db.ProjectWithTag) *project.Project {
 				ProjectId: t.ProjectID,
 				Tag:       t.Tag,
 				Color:     t.Color,
-				// CreatedAt: t.CreatedAt.Unix(), // Reduce the API response size
-				// UpdatedAt: t.UpdatedAt.Unix(),
 			})
 		}
 	}
@@ -76,7 +74,8 @@ func (p *ProjectService) CreateProject(ctx context.Context, req *project.CreateP
 	if err := p.createDefaultRole(ctx, req.UserId, pr.ProjectID); err != nil {
 		return nil, err
 	}
-	appLogger.Infof(ctx, "Project created: owner=%d, project=%+v", req.UserId, pr)
+	p.logger.Infof(ctx, "Project created: owner=%d, project=%+v", req.UserId, pr)
+
 	return &project.CreateProjectResponse{Project: convertProject(pr)}, nil
 }
 
@@ -98,7 +97,9 @@ func (p *ProjectService) DeleteProject(ctx context.Context, req *project.DeleteP
 	if err := p.deleteAllProjectRole(ctx, req.ProjectId); err != nil {
 		return nil, err
 	}
-	appLogger.Infof(ctx, "Project deleted: project=%+v", req.ProjectId)
+
+	p.logger.Infof(ctx, "Project deleted: project=%+v", req.ProjectId)
+
 	return &empty.Empty{}, nil
 }
 

--- a/pkg/server/project/project_test.go
+++ b/pkg/server/project/project_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"google.golang.org/protobuf/types/known/emptypb"
 	"gorm.io/gorm"
+	"github.com/ca-risken/common/pkg/logging"
 
 	iammock "github.com/ca-risken/core/proto/iam/mocks"
 )
@@ -96,6 +97,7 @@ func TestCreateProject(t *testing.T) {
 	svc := ProjectService{
 		repository: &mockDB,
 		iamClient:  &mockIAM,
+		logger:     logging.NewLogger(),
 	}
 	cases := []struct {
 		name                  string
@@ -222,6 +224,7 @@ func TestDeleteProject(t *testing.T) {
 	mockIAM := iammock.IAMServiceClient{}
 	svc := ProjectService{
 		iamClient: &mockIAM,
+		logger:     logging.NewLogger(),
 	}
 	cases := []struct {
 		name             string

--- a/pkg/server/project/service.go
+++ b/pkg/server/project/service.go
@@ -1,6 +1,7 @@
 package project
 
 import (
+	"github.com/ca-risken/common/pkg/logging"
 	"github.com/ca-risken/core/pkg/db"
 	"github.com/ca-risken/core/proto/iam"
 )
@@ -8,11 +9,13 @@ import (
 type ProjectService struct {
 	repository db.ProjectRepository
 	iamClient  iam.IAMServiceClient
+	logger     logging.Logger
 }
 
-func NewProjectService(repository db.ProjectRepository, iamClient iam.IAMServiceClient) *ProjectService {
+func NewProjectService(repository db.ProjectRepository, iamClient iam.IAMServiceClient, logger logging.Logger) *ProjectService {
 	return &ProjectService{
 		repository: repository,
 		iamClient:  iamClient,
+		logger:     logger,
 	}
 }

--- a/pkg/server/report/logger.go
+++ b/pkg/server/report/logger.go
@@ -1,5 +1,0 @@
-package report
-
-import "github.com/ca-risken/common/pkg/logging"
-
-var appLogger = logging.NewLogger()

--- a/pkg/server/report/report.go
+++ b/pkg/server/report/report.go
@@ -54,7 +54,6 @@ func (f *ReportService) GetReportFindingAll(ctx context.Context, req *report.Get
 func (f *ReportService) CollectReportFinding(ctx context.Context, req *empty.Empty) (*empty.Empty, error) {
 	err := f.repository.CollectReportFinding(ctx)
 	if err != nil {
-		appLogger.Errorf(ctx, "Failed collectReportFinding. %v", err)
 		return nil, err
 	}
 

--- a/pkg/server/report/service.go
+++ b/pkg/server/report/service.go
@@ -1,13 +1,18 @@
 package report
 
-import "github.com/ca-risken/core/pkg/db"
+import (
+	"github.com/ca-risken/common/pkg/logging"
+	"github.com/ca-risken/core/pkg/db"
+)
 
 type ReportService struct {
 	repository db.ReportRepository
+	logger     logging.Logger
 }
 
-func NewReportService(repository db.ReportRepository) *ReportService {
+func NewReportService(repository db.ReportRepository, logger logging.Logger) *ReportService {
 	return &ReportService{
 		repository: repository,
+		logger:     logger,
 	}
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -65,7 +65,7 @@ func NewConfig(maxAnalyzeAPICall int64, notificationAlertURL string) Config {
 func (s *Server) Run(ctx context.Context) error {
 	clientAddr := fmt.Sprintf("localhost:%s", s.port)
 	fc := s.newFindingClient(clientAddr)
-	isvc := iamserver.NewIAMService(s.db, fc)
+	isvc := iamserver.NewIAMService(s.db, fc, s.logger)
 	asvc := alertserver.NewAlertService(
 		s.config.MaxAnalyzeAPICall,
 		s.config.NotificationAlertURL,
@@ -73,9 +73,9 @@ func (s *Server) Run(ctx context.Context) error {
 		s.newProjectClient(clientAddr),
 		s.db,
 	)
-	fsvc := findingserver.NewFindingService(s.db)
-	psvc := projectserver.NewProjectService(s.db, s.newIAMClient(clientAddr))
-	rsvc := reportserver.NewReportService(s.db)
+	fsvc := findingserver.NewFindingService(s.db, s.logger)
+	psvc := projectserver.NewProjectService(s.db, s.newIAMClient(clientAddr), s.logger)
+	rsvc := reportserver.NewReportService(s.db, s.logger)
 	hsvc := health.NewServer()
 
 	server := grpc.NewServer(


### PR DESCRIPTION
logger.goを削除し、loggerを生成するところを一つにしました。
alertは変更が入る予定であるため、今回は対応を見送ります。
また、不要と思われるログは一部削除しました。