### PR TITLE
fix clearScore validation

### DIFF
--- a/proto/finding/validator.go
+++ b/proto/finding/validator.go
@@ -162,7 +162,7 @@ func (u *UntagFindingRequest) Validate() error {
 func (c *ClearScoreRequest) Validate() error {
 	return validation.ValidateStruct(c,
 		validation.Field(&c.DataSource, validation.Required, validation.Length(0, 64)),
-		validation.Field(&c.Tag, validation.Each(validation.Length(0, 64))),
+		validation.Field(&c.Tag, validation.Each(validation.Length(0, 255))),
 	)
 }
 

--- a/proto/finding/validator_test.go
+++ b/proto/finding/validator_test.go
@@ -536,7 +536,7 @@ func TestValidate_ClearScoreRequest(t *testing.T) {
 		},
 		{
 			name:    "NG Length(finding_tag_id)",
-			input:   &ClearScoreRequest{DataSource: "ds", Tag: []string{"tag1", len65string}},
+			input:   &ClearScoreRequest{DataSource: "ds", Tag: []string{"tag1", len256string}},
 			wantErr: true,
 		},
 	}


### PR DESCRIPTION
clearScoreのresouceNameパラメータのバリデーションが漏れていたことを修正
resourceNameの最大長が255になったので、それに合わせて変更します