### PR TITLE
rm: regexp SQL

### DIFF
--- a/pkg/db/finding.go
+++ b/pkg/db/finding.go
@@ -150,13 +150,17 @@ where
 	}
 	if len(dataSources) > 0 {
 		sql, sqlParams := generatePrefixMatchSQLStatement("finding.data_source", dataSources)
-		query += fmt.Sprintf(" and (%s)", sql)
-		params = append(params, sqlParams...)
+		if sql != "" {
+			query += fmt.Sprintf(" and (%s)", sql)
+			params = append(params, sqlParams...)
+		}
 	}
 	if len(resourceNames) > 0 {
 		sql, sqlParams := generatePrefixMatchSQLStatement("finding.resource_name", resourceNames)
-		query += fmt.Sprintf(" and (%s)", sql)
-		params = append(params, sqlParams...)
+		if sql != "" {
+			query += fmt.Sprintf(" and (%s)", sql)
+			params = append(params, sqlParams...)
+		}
 	}
 	// EXISTS and NOT EXISTS subquery cause performance slow so used join clause instead
 	if len(tags) > 0 {
@@ -519,8 +523,10 @@ where
 	}
 	if len(req.ResourceName) > 0 {
 		sql, sqlParams := generatePrefixMatchSQLStatement("r.resource_name", req.ResourceName)
-		query += fmt.Sprintf(" and (%s)", sql)
-		params = append(params, sqlParams...)
+		if sql != "" {
+			query += fmt.Sprintf(" and (%s)", sql)
+			params = append(params, sqlParams...)
+		}
 	}
 	if len(req.Tag) > 0 {
 		for _, tag := range req.Tag {
@@ -559,8 +565,10 @@ select count(*) from (
 	}
 	if len(req.ResourceName) > 0 {
 		sql, sqlParams := generatePrefixMatchSQLStatement("r.resource_name", req.ResourceName)
-		query += fmt.Sprintf(" and (%s)", sql)
-		params = append(params, sqlParams...)
+		if sql != "" {
+			query += fmt.Sprintf(" and (%s)", sql)
+			params = append(params, sqlParams...)
+		}
 	}
 	if len(req.Tag) > 0 {
 		for _, tag := range req.Tag {

--- a/pkg/db/finding.go
+++ b/pkg/db/finding.go
@@ -149,12 +149,14 @@ where
 		params = append(params, findingID)
 	}
 	if len(dataSources) > 0 {
-		query += " and finding.data_source regexp ?"
-		params = append(params, strings.Join(dataSources, "|"))
+		sql, sqlParams := generatePrefixMatchSQLStatement("finding.data_source", dataSources)
+		query += fmt.Sprintf(" and (%s)", sql)
+		params = append(params, sqlParams...)
 	}
 	if len(resourceNames) > 0 {
-		query += " and finding.resource_name regexp ?"
-		params = append(params, strings.Join(resourceNames, "|"))
+		sql, sqlParams := generatePrefixMatchSQLStatement("finding.resource_name", resourceNames)
+		query += fmt.Sprintf(" and (%s)", sql)
+		params = append(params, sqlParams...)
 	}
 	// EXISTS and NOT EXISTS subquery cause performance slow so used join clause instead
 	if len(tags) > 0 {
@@ -170,6 +172,20 @@ where
 		join += " inner join pend_finding using(finding_id)"
 	}
 	return join + query, params
+}
+
+func generatePrefixMatchSQLStatement(column string, params []string) (sql string, sqlParams []interface{}) {
+	for _, p := range params {
+		if p == "" {
+			continue
+		}
+		if sql != "" {
+			sql += " or "
+		}
+		sql += fmt.Sprintf("%s like ?", column)
+		sqlParams = append(sqlParams, p+"%") // prefix match
+	}
+	return sql, sqlParams
 }
 
 const selectGetFinding = `select * from finding where project_id = ? and finding_id = ?`
@@ -502,8 +518,9 @@ where
 		params = append(params, req.ResourceId)
 	}
 	if len(req.ResourceName) > 0 {
-		query += " and r.resource_name regexp ?"
-		params = append(params, strings.Join(req.ResourceName, "|"))
+		sql, sqlParams := generatePrefixMatchSQLStatement("r.resource_name", req.ResourceName)
+		query += fmt.Sprintf(" and (%s)", sql)
+		params = append(params, sqlParams...)
 	}
 	if len(req.Tag) > 0 {
 		for _, tag := range req.Tag {
@@ -541,8 +558,9 @@ select count(*) from (
 		params = append(params, req.ResourceId)
 	}
 	if len(req.ResourceName) > 0 {
-		query += " and r.resource_name regexp ?"
-		params = append(params, strings.Join(req.ResourceName, "|"))
+		sql, sqlParams := generatePrefixMatchSQLStatement("r.resource_name", req.ResourceName)
+		query += fmt.Sprintf(" and (%s)", sql)
+		params = append(params, sqlParams...)
 	}
 	if len(req.Tag) > 0 {
 		for _, tag := range req.Tag {

--- a/pkg/db/finding_test.go
+++ b/pkg/db/finding_test.go
@@ -825,7 +825,7 @@ func TestGeneratePrefixMatchSQLStatement(t *testing.T) {
 				column: "name",
 				params: []string{"aaa"},
 			},
-			wantSQL:   `name like ?`,
+			wantSQL:   "name like ?",
 			wantParam: []interface{}{"aaa%"},
 		},
 		{
@@ -834,7 +834,7 @@ func TestGeneratePrefixMatchSQLStatement(t *testing.T) {
 				column: "name",
 				params: []string{"aaa", "bbb"},
 			},
-			wantSQL:   `name like ? or name like ?`,
+			wantSQL:   "name like ? or name like ?",
 			wantParam: []interface{}{"aaa%", "bbb%"},
 		},
 		{
@@ -843,8 +843,17 @@ func TestGeneratePrefixMatchSQLStatement(t *testing.T) {
 				column: "name",
 				params: []string{"aaa", "bbb", ""},
 			},
-			wantSQL:   `name like ? or name like ?`,
+			wantSQL:   "name like ? or name like ?",
 			wantParam: []interface{}{"aaa%", "bbb%"},
+		},
+		{
+			name: "All blank param",
+			input: args{
+				column: "name",
+				params: []string{"", "", ""},
+			},
+			wantSQL:   "",
+			wantParam: nil,
 		},
 	}
 	for _, c := range cases {

--- a/pkg/db/finding_test.go
+++ b/pkg/db/finding_test.go
@@ -807,3 +807,55 @@ ON DUPLICATE KEY UPDATE
 		})
 	}
 }
+
+func TestGeneratePrefixMatchSQLStatement(t *testing.T) {
+	type args struct {
+		column string
+		params []string
+	}
+	cases := []struct {
+		name      string
+		input     args
+		wantSQL   string
+		wantParam []interface{}
+	}{
+		{
+			name: "Single param",
+			input: args{
+				column: "name",
+				params: []string{"aaa"},
+			},
+			wantSQL:   `name like ?`,
+			wantParam: []interface{}{"aaa%"},
+		},
+		{
+			name: "Multi params",
+			input: args{
+				column: "name",
+				params: []string{"aaa", "bbb"},
+			},
+			wantSQL:   `name like ? or name like ?`,
+			wantParam: []interface{}{"aaa%", "bbb%"},
+		},
+		{
+			name: "Blank param",
+			input: args{
+				column: "name",
+				params: []string{"aaa", "bbb", ""},
+			},
+			wantSQL:   `name like ? or name like ?`,
+			wantParam: []interface{}{"aaa%", "bbb%"},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			sql, param := generatePrefixMatchSQLStatement(c.input.column, c.input.params)
+			if !reflect.DeepEqual(sql, c.wantSQL) {
+				t.Fatalf("Unexpected SQL response: want=%s, got=%s", c.wantSQL, sql)
+			}
+			if !reflect.DeepEqual(param, c.wantParam) {
+				t.Fatalf("Unexpected param response: want=%+v, got=%+v", c.wantParam, param)
+			}
+		})
+	}
+}


### PR DESCRIPTION
パフォーマンスの問題でSQLで `regexp` 条件を使用している箇所をLIKEに変更します。
また、DBのindexが利用されるよう前方一致検索に変更します
（これまで、部分一致検索を許容していたので機能劣化になります。RISKEN内のシステムで部分一致を利用しているユースケースがないのと、システムパフォーマンスを優先する判断です）

この修正で影響を受けるAPIはいかになります
- ListFinding(resrouce_name, data_source)
- BatchListFinding(resrouce_name, data_source)
- ListResource(resrouce_name)