### PR TITLE
Resolve missing error in pkg/db

### DIFF
--- a/main.go
+++ b/main.go
@@ -91,7 +91,10 @@ func main() {
 		LogMode:        conf.DBLogMode,
 		MaxConnection:  conf.DBMaxConnection,
 	}
-	db := db.NewClient(dbConf, logger)
+	db, err := db.NewClient(dbConf, logger)
+	if err != nil {
+		logger.Fatalf(ctx, "failed to create database client: %w", err)
+	}
 	c := server.NewConfig(conf.MaxAnalyzeAPICall, conf.NotificationAlertURL)
 	server := server.NewServer("0.0.0.0", conf.Port, db, logger, c)
 

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -18,25 +18,25 @@ type Client struct {
 	logger logging.Logger
 }
 
-func NewClient(conf *Config, l logging.Logger) *Client {
+func NewClient(conf *Config, l logging.Logger) (*Client, error) {
 	ctx := context.Background()
 	m, err := connect(conf, true)
 	if err != nil {
-		l.Fatalf(ctx, "failed to connect database: %w", err)
+		return nil, fmt.Errorf("failed to connect database of master: %w", err)
 	}
-	l.Infof(ctx, "Connected to Database. isMaster: %t", true)
+	l.Info(ctx, "Connected to Database of master.")
 
 	s, err := connect(conf, false)
 	if err != nil {
-		l.Fatalf(ctx, "failed to connect database: %w", err)
+		return nil, fmt.Errorf("failed to connect database of slave: %w", err)
 	}
-	l.Infof(ctx, "Connected to Database. isMaster: %t", false)
+	l.Info(ctx, "Connected to Database of slave.")
 
 	return &Client{
 		Master: m,
 		Slave:  s,
 		logger: l,
-	}
+	}, nil
 }
 
 func newMockClient() (*Client, sqlmock.Sqlmock, error) {


### PR DESCRIPTION
pkg/db配下のfunctionで、発生したerrorを呼び出し元に返していなかったものがあったので呼び出し元に返すよう変更。

`db.NewClient`は、function内でexitするのではなくmainでexitするためにerrorを返すようにしました。