### PR TITLE
Resolve missing error in pkg/server

### DIFF
--- a/pkg/server/alert/alert_analyze.go
+++ b/pkg/server/alert/alert_analyze.go
@@ -484,7 +484,7 @@ func makeRandomStr(digit uint32) (string, error) {
 	// 乱数を生成
 	b := make([]byte, digit)
 	if _, err := rand.Read(b); err != nil {
-		return "", errors.New("unexpected error...")
+		return "", fmt.Errorf("failed to read random, err=%w", err)
 	}
 
 	// letters からランダムに取り出して文字列を生成

--- a/pkg/server/finding/finding_setting.go
+++ b/pkg/server/finding/finding_setting.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"strings"
 
 	"github.com/ca-risken/core/pkg/model"
@@ -125,8 +126,7 @@ func (f *FindingService) getFindingSettingByResource(ctx context.Context, projec
 	}
 	var setting findingSetting
 	if err := json.Unmarshal([]byte(fs.Setting), &setting); err != nil {
-		f.logger.Warnf(ctx, "Failed to unmarshal finding setting JSON, projectID=%d, resourceName=%s, err=%+v", projectID, resourceName, err)
-		return &findingSetting{}, nil
+		return nil, fmt.Errorf("failed to unmarshal finding setting JSON, projectID=%d, resourceName=%s, err=%w", projectID, resourceName, err)
 	}
 	return &setting, nil
 }


### PR DESCRIPTION
pkg/server配下のfunctionで、発生したerrorを呼び出し元に返していなかったものがあったので呼び出し元に返すよう変更
grpcのclientを生成するfunctionは、function内でexitするのではなく呼び出し元でハンドリングするためにerrorを返すようにしました。