### PR TITLE
add: exponential backoff

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,7 @@ test:
 
 .PHONY: lint
 lint: FAKE
-	GO111MODULE=on golangci-lint run --timeout 5m
+	GO111MODULE=on GOFLAGS=-buildvcs=false golangci-lint run --timeout 5m
 
 .PHONY: generate-mock
 generate-mock: proto-mock

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/ca-risken/common/pkg/profiler v0.0.0-20220426050416-a654045b9fa5
 	github.com/ca-risken/common/pkg/rpc v0.0.0-20220518032134-ad443b601efd
 	github.com/ca-risken/common/pkg/tracer v0.0.0-20220426050416-a654045b9fa5
+	github.com/cenkalti/backoff/v4 v4.2.0
 	github.com/envoyproxy/protoc-gen-validate v0.6.7
 	github.com/gassara-kys/envconfig v1.4.4
 	github.com/go-ozzo/ozzo-validation/v4 v4.3.0

--- a/go.sum
+++ b/go.sum
@@ -96,6 +96,8 @@ github.com/ca-risken/common/pkg/rpc v0.0.0-20220518032134-ad443b601efd h1:rrkuvy
 github.com/ca-risken/common/pkg/rpc v0.0.0-20220518032134-ad443b601efd/go.mod h1:fnvFF8ESVirs5LV36leyFKf3FbuqjLDhJnipGJgDZtA=
 github.com/ca-risken/common/pkg/tracer v0.0.0-20220426050416-a654045b9fa5 h1:uWLkCDh/N4eXKBMaVfd3bbxA3R3oi6RKe4ZYuuJ5WcI=
 github.com/ca-risken/common/pkg/tracer v0.0.0-20220426050416-a654045b9fa5/go.mod h1:PIXjETIPseBEB/OXp5Rxn8FFuRwfQjFZe1VN+0Skh2E=
+github.com/cenkalti/backoff/v4 v4.2.0 h1:HN5dHm3WBOgndBH6E8V0q2jIYIR3s9yglV8k/+MN3u4=
+github.com/cenkalti/backoff/v4 v4.2.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cespare/xxhash/v2 v2.1.2 h1:YRXhKfTDauu4ajMg1TPgFO5jnlC2HCbmLXMcTG5cbYE=

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -3,6 +3,7 @@ package db
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"gorm.io/driver/mysql"
 	"gorm.io/gorm"
@@ -98,4 +99,10 @@ func connect(conf *Config, isMaster bool) (*gorm.DB, error) {
 	}
 
 	return db, nil
+}
+
+func (c *Client) newRetryLogger(ctx context.Context, funcName string) func(error, time.Duration) {
+	return func(err error, t time.Duration) {
+		c.logger.Warnf(ctx, "[RetryLogger] %s error: duration=%+v, err=%+v", funcName, t, err)
+	}
 }

--- a/pkg/db/finding.go
+++ b/pkg/db/finding.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/ca-risken/core/pkg/model"
 	"github.com/ca-risken/core/proto/finding"
+	"github.com/cenkalti/backoff/v4"
 	"github.com/vikyd/zero"
 )
 
@@ -383,6 +384,16 @@ func (c *Client) UntagFinding(ctx context.Context, projectID uint32, findingTagI
 }
 
 func (c *Client) ClearScoreFinding(ctx context.Context, req *finding.ClearScoreRequest) error {
+	operation := func() error {
+		return c.clearScoreFinding(ctx, req)
+	}
+	retryLogger := func(err error, t time.Duration) {
+		c.logger.Warnf(ctx, "[Retryer]ClearScoreFinding error: duration=%+v, err=%+v", t, err)
+	}
+	return backoff.RetryNotify(operation, c.retryer, retryLogger)
+}
+
+func (c *Client) clearScoreFinding(ctx context.Context, req *finding.ClearScoreRequest) error {
 	var params []interface{}
 	sql := `update finding f left outer join finding_tag ft using(finding_id) set f.score=0.0 where f.score > 0.0 and f.data_source = ?`
 
@@ -403,6 +414,16 @@ func (c *Client) ClearScoreFinding(ctx context.Context, req *finding.ClearScoreR
 }
 
 func (c *Client) BulkUpsertFinding(ctx context.Context, data []*model.Finding) error {
+	operation := func() error {
+		return c.bulkUpsertFinding(ctx, data)
+	}
+	retryLogger := func(err error, t time.Duration) {
+		c.logger.Warnf(ctx, "[Retryer]BulkUpsertFinding error: duration=%+v, err=%+v", t, err)
+	}
+	return backoff.RetryNotify(operation, c.retryer, retryLogger)
+}
+
+func (c *Client) bulkUpsertFinding(ctx context.Context, data []*model.Finding) error {
 	if len(data) == 0 {
 		return nil
 	}
@@ -436,6 +457,16 @@ ON DUPLICATE KEY UPDATE
 }
 
 func (c *Client) BulkUpsertFindingTag(ctx context.Context, data []*model.FindingTag) error {
+	operation := func() error {
+		return c.bulkUpsertFindingTag(ctx, data)
+	}
+	retryLogger := func(err error, t time.Duration) {
+		c.logger.Warnf(ctx, "[Retryer]BulkUpsertFindingTag error: duration=%+v, err=%+v", t, err)
+	}
+	return backoff.RetryNotify(operation, c.retryer, retryLogger)
+}
+
+func (c *Client) bulkUpsertFindingTag(ctx context.Context, data []*model.FindingTag) error {
 	if len(data) == 0 {
 		return nil
 	}
@@ -768,6 +799,16 @@ func (c *Client) UntagResource(ctx context.Context, projectID uint32, resourceTa
 }
 
 func (c *Client) BulkUpsertResource(ctx context.Context, data []*model.Resource) error {
+	operation := func() error {
+		return c.bulkUpsertResource(ctx, data)
+	}
+	retryLogger := func(err error, t time.Duration) {
+		c.logger.Warnf(ctx, "[Retryer]BulkUpsertResource error: duration=%+v, err=%+v", t, err)
+	}
+	return backoff.RetryNotify(operation, c.retryer, retryLogger)
+}
+
+func (c *Client) bulkUpsertResource(ctx context.Context, data []*model.Resource) error {
 	if len(data) == 0 {
 		return nil
 	}
@@ -796,6 +837,16 @@ ON DUPLICATE KEY UPDATE
 }
 
 func (c *Client) BulkUpsertResourceTag(ctx context.Context, data []*model.ResourceTag) error {
+	operation := func() error {
+		return c.bulkUpsertResourceTag(ctx, data)
+	}
+	retryLogger := func(err error, t time.Duration) {
+		c.logger.Warnf(ctx, "[Retryer]BulkUpsertResourceTag error: duration=%+v, err=%+v", t, err)
+	}
+	return backoff.RetryNotify(operation, c.retryer, retryLogger)
+}
+
+func (c *Client) bulkUpsertResourceTag(ctx context.Context, data []*model.ResourceTag) error {
 	if len(data) == 0 {
 		return nil
 	}
@@ -867,6 +918,16 @@ func (c *Client) GetRecommendByDataSourceType(ctx context.Context, dataSource, r
 }
 
 func (c *Client) BulkUpsertRecommend(ctx context.Context, data []*model.Recommend) error {
+	operation := func() error {
+		return c.bulkUpsertRecommend(ctx, data)
+	}
+	retryLogger := func(err error, t time.Duration) {
+		c.logger.Warnf(ctx, "[Retryer]BulkUpsertRecommend error: duration=%+v, err=%+v", t, err)
+	}
+	return backoff.RetryNotify(operation, c.retryer, retryLogger)
+}
+
+func (c *Client) bulkUpsertRecommend(ctx context.Context, data []*model.Recommend) error {
 	if len(data) == 0 {
 		return nil
 	}
@@ -897,6 +958,16 @@ ON DUPLICATE KEY UPDATE
 }
 
 func (c *Client) BulkUpsertRecommendFinding(ctx context.Context, data []*model.RecommendFinding) error {
+	operation := func() error {
+		return c.bulkUpsertRecommendFinding(ctx, data)
+	}
+	retryLogger := func(err error, t time.Duration) {
+		c.logger.Warnf(ctx, "[Retryer]BulkUpsertRecommendFinding error: duration=%+v, err=%+v", t, err)
+	}
+	return backoff.RetryNotify(operation, c.retryer, retryLogger)
+}
+
+func (c *Client) bulkUpsertRecommendFinding(ctx context.Context, data []*model.RecommendFinding) error {
 	if len(data) == 0 {
 		return nil
 	}

--- a/pkg/db/finding.go
+++ b/pkg/db/finding.go
@@ -244,6 +244,16 @@ ON DUPLICATE KEY UPDATE
 `
 
 func (c *Client) UpsertFinding(ctx context.Context, data *model.Finding) (*model.Finding, error) {
+	operation := func() (*model.Finding, error) {
+		return c.upsertFinding(ctx, data)
+	}
+	retryLogger := func(err error, t time.Duration) {
+		c.logger.Warnf(ctx, "[Retryer]UpsertFinding error: duration=%+v, err=%+v", t, err)
+	}
+	return backoff.RetryNotifyWithData(operation, c.retryer, retryLogger)
+}
+
+func (c *Client) upsertFinding(ctx context.Context, data *model.Finding) (*model.Finding, error) {
 	if err := c.Master.WithContext(ctx).Exec(insertUpsertFinding,
 		data.FindingID, data.Description, data.DataSource, data.DataSourceID, data.ResourceName,
 		data.ProjectID, data.OriginalScore, data.Score, data.Data).Error; err != nil {
@@ -360,6 +370,16 @@ ON DUPLICATE KEY UPDATE
 `
 
 func (c *Client) TagFinding(ctx context.Context, tag *model.FindingTag) (*model.FindingTag, error) {
+	operation := func() (*model.FindingTag, error) {
+		return c.tagFinding(ctx, tag)
+	}
+	retryLogger := func(err error, t time.Duration) {
+		c.logger.Warnf(ctx, "[Retryer]TagFinding error: duration=%+v, err=%+v", t, err)
+	}
+	return backoff.RetryNotifyWithData(operation, c.retryer, retryLogger)
+}
+
+func (c *Client) tagFinding(ctx context.Context, tag *model.FindingTag) (*model.FindingTag, error) {
 	if err := c.Master.WithContext(ctx).Exec(insertTagFinding,
 		tag.FindingTagID, tag.FindingID, tag.ProjectID, tag.Tag).Error; err != nil {
 		return nil, err
@@ -748,6 +768,16 @@ ON DUPLICATE KEY UPDATE
 `
 
 func (c *Client) UpsertResource(ctx context.Context, data *model.Resource) (*model.Resource, error) {
+	operation := func() (*model.Resource, error) {
+		return c.upsertResource(ctx, data)
+	}
+	retryLogger := func(err error, t time.Duration) {
+		c.logger.Warnf(ctx, "[Retryer]UpsertResource error: duration=%+v, err=%+v", t, err)
+	}
+	return backoff.RetryNotifyWithData(operation, c.retryer, retryLogger)
+}
+
+func (c *Client) upsertResource(ctx context.Context, data *model.Resource) (*model.Resource, error) {
 	if err := c.Master.WithContext(ctx).Exec(insertUpsertResource,
 		data.ResourceID, data.ResourceName, data.ProjectID).Error; err != nil {
 		return nil, err
@@ -785,6 +815,16 @@ ON DUPLICATE KEY UPDATE
 `
 
 func (c *Client) TagResource(ctx context.Context, tag *model.ResourceTag) (*model.ResourceTag, error) {
+	operation := func() (*model.ResourceTag, error) {
+		return c.tagResource(ctx, tag)
+	}
+	retryLogger := func(err error, t time.Duration) {
+		c.logger.Warnf(ctx, "[Retryer]TagResource error: duration=%+v, err=%+v", t, err)
+	}
+	return backoff.RetryNotifyWithData(operation, c.retryer, retryLogger)
+}
+
+func (c *Client) tagResource(ctx context.Context, tag *model.ResourceTag) (*model.ResourceTag, error) {
 	if err := c.Master.WithContext(ctx).Exec(insertTagResource,
 		tag.ResourceTagID, tag.ResourceID, tag.ProjectID, tag.Tag).Error; err != nil {
 		return nil, err
@@ -888,6 +928,16 @@ func (c *Client) GetRecommend(ctx context.Context, projectID uint32, findingID u
 }
 
 func (c *Client) UpsertRecommend(ctx context.Context, data *model.Recommend) (*model.Recommend, error) {
+	operation := func() (*model.Recommend, error) {
+		return c.upsertRecommend(ctx, data)
+	}
+	retryLogger := func(err error, t time.Duration) {
+		c.logger.Warnf(ctx, "[Retryer]UpsertRecommend error: duration=%+v, err=%+v", t, err)
+	}
+	return backoff.RetryNotifyWithData(operation, c.retryer, retryLogger)
+}
+
+func (c *Client) upsertRecommend(ctx context.Context, data *model.Recommend) (*model.Recommend, error) {
 	var ret model.Recommend
 	if err := c.Master.WithContext(ctx).Where("data_source=? AND type=?", data.DataSource, data.Type).Assign(data).FirstOrCreate(&ret).Error; err != nil {
 		return nil, err
@@ -896,6 +946,16 @@ func (c *Client) UpsertRecommend(ctx context.Context, data *model.Recommend) (*m
 }
 
 func (c *Client) UpsertRecommendFinding(ctx context.Context, data *model.RecommendFinding) (*model.RecommendFinding, error) {
+	operation := func() (*model.RecommendFinding, error) {
+		return c.upsertRecommendFinding(ctx, data)
+	}
+	retryLogger := func(err error, t time.Duration) {
+		c.logger.Warnf(ctx, "[Retryer]UpsertRecommendFinding error: duration=%+v, err=%+v", t, err)
+	}
+	return backoff.RetryNotifyWithData(operation, c.retryer, retryLogger)
+}
+
+func (c *Client) upsertRecommendFinding(ctx context.Context, data *model.RecommendFinding) (*model.RecommendFinding, error) {
 	var ret model.RecommendFinding
 	if err := c.Master.WithContext(ctx).Where("finding_id=?", data.FindingID).Assign(data).FirstOrCreate(&ret).Error; err != nil {
 		return nil, err

--- a/pkg/db/finding.go
+++ b/pkg/db/finding.go
@@ -247,10 +247,7 @@ func (c *Client) UpsertFinding(ctx context.Context, data *model.Finding) (*model
 	operation := func() (*model.Finding, error) {
 		return c.upsertFinding(ctx, data)
 	}
-	retryLogger := func(err error, t time.Duration) {
-		c.logger.Warnf(ctx, "[Retryer]UpsertFinding error: duration=%+v, err=%+v", t, err)
-	}
-	return backoff.RetryNotifyWithData(operation, c.retryer, retryLogger)
+	return backoff.RetryNotifyWithData(operation, c.retryer, c.newRetryLogger(ctx, "UpsertFinding"))
 }
 
 func (c *Client) upsertFinding(ctx context.Context, data *model.Finding) (*model.Finding, error) {
@@ -373,10 +370,7 @@ func (c *Client) TagFinding(ctx context.Context, tag *model.FindingTag) (*model.
 	operation := func() (*model.FindingTag, error) {
 		return c.tagFinding(ctx, tag)
 	}
-	retryLogger := func(err error, t time.Duration) {
-		c.logger.Warnf(ctx, "[Retryer]TagFinding error: duration=%+v, err=%+v", t, err)
-	}
-	return backoff.RetryNotifyWithData(operation, c.retryer, retryLogger)
+	return backoff.RetryNotifyWithData(operation, c.retryer, c.newRetryLogger(ctx, "TagFinding"))
 }
 
 func (c *Client) tagFinding(ctx context.Context, tag *model.FindingTag) (*model.FindingTag, error) {
@@ -407,10 +401,7 @@ func (c *Client) ClearScoreFinding(ctx context.Context, req *finding.ClearScoreR
 	operation := func() error {
 		return c.clearScoreFinding(ctx, req)
 	}
-	retryLogger := func(err error, t time.Duration) {
-		c.logger.Warnf(ctx, "[Retryer]ClearScoreFinding error: duration=%+v, err=%+v", t, err)
-	}
-	return backoff.RetryNotify(operation, c.retryer, retryLogger)
+	return backoff.RetryNotify(operation, c.retryer, c.newRetryLogger(ctx, "ClearScoreFinding"))
 }
 
 func (c *Client) clearScoreFinding(ctx context.Context, req *finding.ClearScoreRequest) error {
@@ -437,10 +428,7 @@ func (c *Client) BulkUpsertFinding(ctx context.Context, data []*model.Finding) e
 	operation := func() error {
 		return c.bulkUpsertFinding(ctx, data)
 	}
-	retryLogger := func(err error, t time.Duration) {
-		c.logger.Warnf(ctx, "[Retryer]BulkUpsertFinding error: duration=%+v, err=%+v", t, err)
-	}
-	return backoff.RetryNotify(operation, c.retryer, retryLogger)
+	return backoff.RetryNotify(operation, c.retryer, c.newRetryLogger(ctx, "BulkUpsertFinding"))
 }
 
 func (c *Client) bulkUpsertFinding(ctx context.Context, data []*model.Finding) error {
@@ -480,10 +468,7 @@ func (c *Client) BulkUpsertFindingTag(ctx context.Context, data []*model.Finding
 	operation := func() error {
 		return c.bulkUpsertFindingTag(ctx, data)
 	}
-	retryLogger := func(err error, t time.Duration) {
-		c.logger.Warnf(ctx, "[Retryer]BulkUpsertFindingTag error: duration=%+v, err=%+v", t, err)
-	}
-	return backoff.RetryNotify(operation, c.retryer, retryLogger)
+	return backoff.RetryNotify(operation, c.retryer, c.newRetryLogger(ctx, "BulkUpsertFindingTag"))
 }
 
 func (c *Client) bulkUpsertFindingTag(ctx context.Context, data []*model.FindingTag) error {
@@ -771,10 +756,7 @@ func (c *Client) UpsertResource(ctx context.Context, data *model.Resource) (*mod
 	operation := func() (*model.Resource, error) {
 		return c.upsertResource(ctx, data)
 	}
-	retryLogger := func(err error, t time.Duration) {
-		c.logger.Warnf(ctx, "[Retryer]UpsertResource error: duration=%+v, err=%+v", t, err)
-	}
-	return backoff.RetryNotifyWithData(operation, c.retryer, retryLogger)
+	return backoff.RetryNotifyWithData(operation, c.retryer, c.newRetryLogger(ctx, "UpsertResource"))
 }
 
 func (c *Client) upsertResource(ctx context.Context, data *model.Resource) (*model.Resource, error) {
@@ -818,10 +800,7 @@ func (c *Client) TagResource(ctx context.Context, tag *model.ResourceTag) (*mode
 	operation := func() (*model.ResourceTag, error) {
 		return c.tagResource(ctx, tag)
 	}
-	retryLogger := func(err error, t time.Duration) {
-		c.logger.Warnf(ctx, "[Retryer]TagResource error: duration=%+v, err=%+v", t, err)
-	}
-	return backoff.RetryNotifyWithData(operation, c.retryer, retryLogger)
+	return backoff.RetryNotifyWithData(operation, c.retryer, c.newRetryLogger(ctx, "TagResource"))
 }
 
 func (c *Client) tagResource(ctx context.Context, tag *model.ResourceTag) (*model.ResourceTag, error) {
@@ -842,10 +821,7 @@ func (c *Client) BulkUpsertResource(ctx context.Context, data []*model.Resource)
 	operation := func() error {
 		return c.bulkUpsertResource(ctx, data)
 	}
-	retryLogger := func(err error, t time.Duration) {
-		c.logger.Warnf(ctx, "[Retryer]BulkUpsertResource error: duration=%+v, err=%+v", t, err)
-	}
-	return backoff.RetryNotify(operation, c.retryer, retryLogger)
+	return backoff.RetryNotify(operation, c.retryer, c.newRetryLogger(ctx, "BulkUpsertResource"))
 }
 
 func (c *Client) bulkUpsertResource(ctx context.Context, data []*model.Resource) error {
@@ -880,10 +856,7 @@ func (c *Client) BulkUpsertResourceTag(ctx context.Context, data []*model.Resour
 	operation := func() error {
 		return c.bulkUpsertResourceTag(ctx, data)
 	}
-	retryLogger := func(err error, t time.Duration) {
-		c.logger.Warnf(ctx, "[Retryer]BulkUpsertResourceTag error: duration=%+v, err=%+v", t, err)
-	}
-	return backoff.RetryNotify(operation, c.retryer, retryLogger)
+	return backoff.RetryNotify(operation, c.retryer, c.newRetryLogger(ctx, "BulkUpsertResourceTag"))
 }
 
 func (c *Client) bulkUpsertResourceTag(ctx context.Context, data []*model.ResourceTag) error {
@@ -931,10 +904,7 @@ func (c *Client) UpsertRecommend(ctx context.Context, data *model.Recommend) (*m
 	operation := func() (*model.Recommend, error) {
 		return c.upsertRecommend(ctx, data)
 	}
-	retryLogger := func(err error, t time.Duration) {
-		c.logger.Warnf(ctx, "[Retryer]UpsertRecommend error: duration=%+v, err=%+v", t, err)
-	}
-	return backoff.RetryNotifyWithData(operation, c.retryer, retryLogger)
+	return backoff.RetryNotifyWithData(operation, c.retryer, c.newRetryLogger(ctx, "UpsertRecommend"))
 }
 
 func (c *Client) upsertRecommend(ctx context.Context, data *model.Recommend) (*model.Recommend, error) {
@@ -949,10 +919,7 @@ func (c *Client) UpsertRecommendFinding(ctx context.Context, data *model.Recomme
 	operation := func() (*model.RecommendFinding, error) {
 		return c.upsertRecommendFinding(ctx, data)
 	}
-	retryLogger := func(err error, t time.Duration) {
-		c.logger.Warnf(ctx, "[Retryer]UpsertRecommendFinding error: duration=%+v, err=%+v", t, err)
-	}
-	return backoff.RetryNotifyWithData(operation, c.retryer, retryLogger)
+	return backoff.RetryNotifyWithData(operation, c.retryer, c.newRetryLogger(ctx, "UpsertRecommendFinding"))
 }
 
 func (c *Client) upsertRecommendFinding(ctx context.Context, data *model.RecommendFinding) (*model.RecommendFinding, error) {
@@ -981,10 +948,7 @@ func (c *Client) BulkUpsertRecommend(ctx context.Context, data []*model.Recommen
 	operation := func() error {
 		return c.bulkUpsertRecommend(ctx, data)
 	}
-	retryLogger := func(err error, t time.Duration) {
-		c.logger.Warnf(ctx, "[Retryer]BulkUpsertRecommend error: duration=%+v, err=%+v", t, err)
-	}
-	return backoff.RetryNotify(operation, c.retryer, retryLogger)
+	return backoff.RetryNotify(operation, c.retryer, c.newRetryLogger(ctx, "BulkUpsertRecommend"))
 }
 
 func (c *Client) bulkUpsertRecommend(ctx context.Context, data []*model.Recommend) error {
@@ -1021,10 +985,7 @@ func (c *Client) BulkUpsertRecommendFinding(ctx context.Context, data []*model.R
 	operation := func() error {
 		return c.bulkUpsertRecommendFinding(ctx, data)
 	}
-	retryLogger := func(err error, t time.Duration) {
-		c.logger.Warnf(ctx, "[Retryer]BulkUpsertRecommendFinding error: duration=%+v, err=%+v", t, err)
-	}
-	return backoff.RetryNotify(operation, c.retryer, retryLogger)
+	return backoff.RetryNotify(operation, c.retryer, c.newRetryLogger(ctx, "BulkUpsertRecommendFinding"))
 }
 
 func (c *Client) bulkUpsertRecommendFinding(ctx context.Context, data []*model.RecommendFinding) error {


### PR DESCRIPTION
Deadlockの対処法として[MySQL公式ドキュメント](https://dev.mysql.com/doc/refman/5.6/ja/innodb-deadlocks.html)を参考にアプリ側にリトライの仕組みを導入しようと思います。

全体に導入するというより、まずは実際にDeadlockが発生している処理にしぼって設定する方針です。
Backoffの実装は以下のライブラリを使いました。
https://pkg.go.dev/github.com/cenkalti/backoff/v4

リトライのロジックは↓準拠のものになっています。
https://en.wikipedia.org/wiki/Exponential_backoff
