### PR TITLE
fix put user

### DIFF
--- a/pkg/db/iam.go
+++ b/pkg/db/iam.go
@@ -125,11 +125,8 @@ INSERT INTO user
 `
 
 func (c *Client) CreateUser(ctx context.Context, u *model.User) (*model.User, error) {
-	userIdpKey := &u.UserIdpKey
-	if *userIdpKey == "" {
-		userIdpKey = nil
-	}
-	if err := c.Master.WithContext(ctx).Exec(insertUser, u.UserID, u.Sub, u.Name, userIdpKey, fmt.Sprintf("%t", u.Activated)).Error; err != nil {
+
+	if err := c.Master.WithContext(ctx).Exec(insertUser, u.UserID, u.Sub, u.Name, convertZeroValueToNull(u.UserIdpKey), fmt.Sprintf("%t", u.Activated)).Error; err != nil {
 		return nil, err
 	}
 	return c.GetUserBySub(ctx, u.Sub)
@@ -145,11 +142,7 @@ UPDATE user
 `
 
 func (c *Client) PutUser(ctx context.Context, u *model.User) (*model.User, error) {
-	userIdpKey := &u.UserIdpKey
-	if *userIdpKey == "" {
-		userIdpKey = nil
-	}
-	if err := c.Master.WithContext(ctx).Exec(updateUser, u.Name, userIdpKey, fmt.Sprintf("%t", u.Activated), u.UserID).Error; err != nil {
+	if err := c.Master.WithContext(ctx).Exec(updateUser, u.Name, convertZeroValueToNull(u.UserIdpKey), fmt.Sprintf("%t", u.Activated), u.UserID).Error; err != nil {
 		return nil, err
 	}
 	return c.GetUserBySub(ctx, u.Sub)

--- a/pkg/db/iam.go
+++ b/pkg/db/iam.go
@@ -125,7 +125,11 @@ INSERT INTO user
 `
 
 func (c *Client) CreateUser(ctx context.Context, u *model.User) (*model.User, error) {
-	if err := c.Master.WithContext(ctx).Exec(insertUser, u.UserID, u.Sub, u.Name, u.UserIdpKey, fmt.Sprintf("%t", u.Activated)).Error; err != nil {
+	userIdpKey := &u.UserIdpKey
+	if *userIdpKey == "" {
+		userIdpKey = nil
+	}
+	if err := c.Master.WithContext(ctx).Exec(insertUser, u.UserID, u.Sub, u.Name, userIdpKey, fmt.Sprintf("%t", u.Activated)).Error; err != nil {
 		return nil, err
 	}
 	return c.GetUserBySub(ctx, u.Sub)
@@ -141,7 +145,11 @@ UPDATE user
 `
 
 func (c *Client) PutUser(ctx context.Context, u *model.User) (*model.User, error) {
-	if err := c.Master.WithContext(ctx).Exec(updateUser, u.Name, u.UserIdpKey, fmt.Sprintf("%t", u.Activated), u.UserID).Error; err != nil {
+	userIdpKey := &u.UserIdpKey
+	if *userIdpKey == "" {
+		userIdpKey = nil
+	}
+	if err := c.Master.WithContext(ctx).Exec(updateUser, u.Name, userIdpKey, fmt.Sprintf("%t", u.Activated), u.UserID).Error; err != nil {
 		return nil, err
 	}
 	return c.GetUserBySub(ctx, u.Sub)


### PR DESCRIPTION
user_idp_keyが空文字の場合、テーブルに空文字で登録する処理をNULLで登録するように修正します。