### PR TITLE
fix put user

### DIFF
--- a/pkg/server/iam/user.go
+++ b/pkg/server/iam/user.go
@@ -77,11 +77,20 @@ func (i *IAMService) PutUser(ctx context.Context, req *iam.PutUserRequest) (*iam
 	var registerdData *model.User
 	// 登録済みユーザーの場合、update
 	if userID != 0 {
+		if req.User.Name == "" {
+			u.Name = savedData.Name
+		}
+		if req.User.UserIdpKey == "" {
+			u.UserIdpKey = savedData.UserIdpKey
+		}
 		registerdData, err = i.repository.PutUser(ctx, u)
 		if err != nil {
 			return nil, err
 		}
 	} else {
+		if req.User.Name == "" {
+			return nil, errors.New("name is required when creating a user")
+		}
 		registerdData, err = i.repository.CreateUser(ctx, u)
 		if err != nil {
 			return nil, err

--- a/pkg/server/iam/user_test.go
+++ b/pkg/server/iam/user_test.go
@@ -154,9 +154,30 @@ func TestPutUser(t *testing.T) {
 			mockUpdResp: &model.User{UserID: 1, Sub: "sub", Name: "nm", UserIdpKey: "uik", Activated: true, CreatedAt: now, UpdatedAt: now},
 		},
 		{
+			name:        "OK Update (Name in request is empty)",
+			input:       &iam.PutUserRequest{User: &iam.UserForUpsert{Sub: "sub", UserIdpKey: "uik", Activated: true}},
+			want:        &iam.PutUserResponse{User: &iam.User{UserId: 1, Sub: "sub", Name: "saved_nm", UserIdpKey: "uik", Activated: true, CreatedAt: now.Unix(), UpdatedAt: now.Unix()}},
+			mockGetResp: &model.User{UserID: 1, Sub: "sub", Name: "saved_nm", UserIdpKey: "uik", Activated: true, CreatedAt: now, UpdatedAt: now},
+			mockUpdResp: &model.User{UserID: 1, Sub: "sub", Name: "saved_nm", UserIdpKey: "uik", Activated: true, CreatedAt: now, UpdatedAt: now},
+		},
+		{
+			name:        "OK Update (UserIdpKey in request is empty)",
+			input:       &iam.PutUserRequest{User: &iam.UserForUpsert{Sub: "sub", Name: "nm", Activated: true}},
+			want:        &iam.PutUserResponse{User: &iam.User{UserId: 1, Sub: "sub", Name: "nm", UserIdpKey: "saved_uik", Activated: true, CreatedAt: now.Unix(), UpdatedAt: now.Unix()}},
+			mockGetResp: &model.User{UserID: 1, Sub: "sub", Name: "nm", UserIdpKey: "saved_uik", Activated: true, CreatedAt: now, UpdatedAt: now},
+			mockUpdResp: &model.User{UserID: 1, Sub: "sub", Name: "nm", UserIdpKey: "saved_uik", Activated: true, CreatedAt: now, UpdatedAt: now},
+		},
+		{
 			name:    "NG Invalid param",
 			input:   &iam.PutUserRequest{User: &iam.UserForUpsert{Name: "nm", Activated: true}},
 			wantErr: true,
+		},
+		{
+			name:       "NG name is empty when Insert",
+			input:      &iam.PutUserRequest{User: &iam.UserForUpsert{Sub: "sub", UserIdpKey: "uik", Activated: true}},
+			want:       nil,
+			mockGetErr: gorm.ErrRecordNotFound,
+			wantErr:    true,
 		},
 		{
 			name:       "NG DB error(GetUserBySub)",

--- a/proto/iam/validator.go
+++ b/proto/iam/validator.go
@@ -36,7 +36,7 @@ func (p *PutUserRequest) Validate() error {
 func (u *UserForUpsert) Validate() error {
 	return validation.ValidateStruct(u,
 		validation.Field(&u.Sub, validation.Required, validation.Length(0, 255)),
-		validation.Field(&u.Name, validation.Required, validation.Length(0, 64)),
+		validation.Field(&u.Name, validation.Length(0, 64)),
 	)
 }
 

--- a/proto/iam/validator_test.go
+++ b/proto/iam/validator_test.go
@@ -128,11 +128,6 @@ func TestValidate_UserForUpsert(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name:    "NG required(name)",
-			input:   &UserForUpsert{Sub: "sub", Activated: true},
-			wantErr: true,
-		},
-		{
 			name:    "NG length(sub)",
 			input:   &UserForUpsert{Sub: "123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789=123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789=12345678901234567890123456789012345678901234567890123456", Name: "nm", Activated: true},
 			wantErr: true,


### PR DESCRIPTION
PutUserからNameのバリデーションを削除します
ユーザー更新時は、Name,UserIdpKeyが空の場合に既存の値を登録するように変更します。
ユーザー新規作成時はNameが空の場合にエラーを返すようにします。