### PR TITLE
fix put user

### DIFF
--- a/pkg/server/iam/user.go
+++ b/pkg/server/iam/user.go
@@ -77,6 +77,9 @@ func (i *IAMService) PutUser(ctx context.Context, req *iam.PutUserRequest) (*iam
 	var registerdData *model.User
 	// 登録済みユーザーの場合、update
 	if userID != 0 {
+		if req.User.UserIdpKey == "" {
+			u.UserIdpKey = savedData.UserIdpKey
+		}
 		registerdData, err = i.repository.PutUser(ctx, u)
 		if err != nil {
 			return nil, err

--- a/pkg/server/iam/user_test.go
+++ b/pkg/server/iam/user_test.go
@@ -154,6 +154,13 @@ func TestPutUser(t *testing.T) {
 			mockUpdResp: &model.User{UserID: 1, Sub: "sub", Name: "nm", UserIdpKey: "uik", Activated: true, CreatedAt: now, UpdatedAt: now},
 		},
 		{
+			name:        "OK Update (UserIdpKey in request is empty)",
+			input:       &iam.PutUserRequest{User: &iam.UserForUpsert{Sub: "sub", Name: "nm", Activated: true}},
+			want:        &iam.PutUserResponse{User: &iam.User{UserId: 1, Sub: "sub", Name: "nm", UserIdpKey: "saved_uik", Activated: true, CreatedAt: now.Unix(), UpdatedAt: now.Unix()}},
+			mockGetResp: &model.User{UserID: 1, Sub: "sub", Name: "nm", UserIdpKey: "saved_uik", Activated: true, CreatedAt: now, UpdatedAt: now},
+			mockUpdResp: &model.User{UserID: 1, Sub: "sub", Name: "nm", UserIdpKey: "saved_uik", Activated: true, CreatedAt: now, UpdatedAt: now},
+		},
+		{
 			name:    "NG Invalid param",
 			input:   &iam.PutUserRequest{User: &iam.UserForUpsert{Name: "nm", Activated: true}},
 			wantErr: true,


### PR DESCRIPTION
ユーザー更新時、UserIdpKeyが空の場合に既存の値を登録するように変更します。