### PR TITLE
delete: project

### DIFF
--- a/pkg/db/mocks/project.go
+++ b/pkg/db/mocks/project.go
@@ -39,3 +39,7 @@ func (m *MockProjectRepository) UntagProject(ctx context.Context, projectID uint
 	args := m.Called()
 	return args.Error(0)
 }
+func (m *MockProjectRepository) DeleteProject(ctx context.Context, projectID uint32) error {
+	args := m.Called()
+	return args.Error(0)
+}

--- a/pkg/db/project.go
+++ b/pkg/db/project.go
@@ -15,6 +15,7 @@ type ProjectRepository interface {
 	ListProject(ctx context.Context, userID, projectID uint32, name string) (*[]ProjectWithTag, error)
 	CreateProject(ctx context.Context, name string) (*model.Project, error)
 	UpdateProject(ctx context.Context, projectID uint32, name string) (*model.Project, error)
+	DeleteProject(ctx context.Context, projectID uint32) error
 
 	TagProject(ctx context.Context, projectID uint32, tag, color string) (*model.ProjectTag, error)
 	UntagProject(ctx context.Context, projectID uint32, tag string) error
@@ -157,6 +158,15 @@ const deleteUntagProject string = `delete from project_tag where project_id=? an
 
 func (c *Client) UntagProject(ctx context.Context, projectID uint32, tag string) error {
 	if err := c.Master.WithContext(ctx).Exec(deleteUntagProject, projectID, tag).Error; err != nil {
+		return err
+	}
+	return nil
+}
+
+const deleteProject = `delete from project where project_id=?`
+
+func (c *Client) DeleteProject(ctx context.Context, projectID uint32) error {
+	if err := c.Master.WithContext(ctx).Exec(deleteProject, projectID).Error; err != nil {
 		return err
 	}
 	return nil

--- a/pkg/db/project_test.go
+++ b/pkg/db/project_test.go
@@ -1,0 +1,55 @@
+package db
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+)
+
+func TestDeleteProject(t *testing.T) {
+	client, mock, err := newMockClient()
+	if err != nil {
+		t.Fatalf("Failed to open mock sql db, error: %+v", err)
+	}
+	type args struct {
+		projectID uint32
+	}
+	cases := []struct {
+		name    string
+		input   args
+		wantErr bool
+		mockErr error
+	}{
+		{
+			name:    "OK",
+			input:   args{projectID: 1},
+			wantErr: false,
+		},
+		{
+			name:    "NG DB error",
+			input:   args{projectID: 1},
+			wantErr: true,
+			mockErr: errors.New("DB error"),
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			ctx := context.Background()
+			if c.mockErr != nil {
+				mock.ExpectExec(deleteProject).WillReturnError(c.mockErr)
+			} else {
+				mock.ExpectExec(deleteProject).WillReturnResult(sqlmock.NewResult(int64(1), int64(1)))
+			}
+
+			err := client.DeleteProject(ctx, c.input.projectID)
+			if err != nil && !c.wantErr {
+				t.Fatalf("Unexpected error: %+v", err)
+			}
+			if err == nil && c.wantErr {
+				t.Fatal("No error")
+			}
+		})
+	}
+}

--- a/pkg/server/project/project.go
+++ b/pkg/server/project/project.go
@@ -94,10 +94,9 @@ func (p *ProjectService) DeleteProject(ctx context.Context, req *project.DeleteP
 	if err := req.Validate(); err != nil {
 		return nil, err
 	}
-	if err := p.deleteAllProjectRole(ctx, req.ProjectId); err != nil {
+	if err := p.repository.DeleteProject(ctx, req.ProjectId); err != nil {
 		return nil, err
 	}
-
 	p.logger.Infof(ctx, "Project deleted: project=%+v", req.ProjectId)
 
 	return &empty.Empty{}, nil
@@ -150,22 +149,6 @@ func (p *ProjectService) createDefaultRole(ctx context.Context, ownerUserID, pro
 		RoleId:    role.Role.RoleId,
 	}); err != nil {
 		return fmt.Errorf("Could not attach default role, err=%+v", err)
-	}
-	return nil
-}
-
-func (p *ProjectService) deleteAllProjectRole(ctx context.Context, projectID uint32) error {
-	list, err := p.iamClient.ListRole(ctx, &iam.ListRoleRequest{ProjectId: projectID})
-	if err != nil {
-		return err
-	}
-	for _, roleID := range list.RoleId {
-		if _, err := p.iamClient.DeleteRole(ctx, &iam.DeleteRoleRequest{
-			ProjectId: projectID,
-			RoleId:    roleID,
-		}); err != nil {
-			return err
-		}
 	}
 	return nil
 }


### PR DESCRIPTION
プロジェクト削除の方針を変更します。
プロジェクト削除のAPIでは大本のプロジェクトデータを削除のみ行い、後ほど非同期で関連データのパージバッチを動かす方式とします。今回は既存APIのロジック修正のみのPRです。