### PR TITLE
fix: alert control

### DIFF
--- a/pkg/server/alert/alert_analyze_test.go
+++ b/pkg/server/alert/alert_analyze_test.go
@@ -404,7 +404,7 @@ func TestRegistAlertByAnalyze(t *testing.T) {
 			if c.mockUpsertRelAlertFinding != nil || c.mockUpsertRelAlertFindingErr != nil {
 				mockDB.On("UpsertRelAlertFinding", test.RepeatMockAnything(2)...).Return(c.mockUpsertRelAlertFinding, c.mockUpsertRelAlertFindingErr).Once()
 			}
-			got, err := svc.RegistAlertByAnalyze(context.Background(), c.alertCondition, c.findingIDs)
+			got, _, err := svc.RegistAlertByAnalyze(context.Background(), c.alertCondition, c.findingIDs)
 			if err != nil && !c.wantErr {
 				t.Fatalf("Unexpected error: %+v", got)
 			}

--- a/pkg/server/alert/alert_notification_test.go
+++ b/pkg/server/alert/alert_notification_test.go
@@ -115,7 +115,7 @@ func TestNotificationAlert(t *testing.T) {
 			if c.mockUpsertAlertCondNotification != nil || c.mockUpsertAlertCondNotificationErr != nil {
 				mockDB.On("UpsertAlertCondNotification", test.RepeatMockAnything(2)...).Return(c.mockUpsertAlertCondNotification, c.mockUpsertAlertCondNotificationErr).Once()
 			}
-			got := svc.NotificationAlert(context.Background(), c.alertCondition, c.alert, &[]model.AlertRule{}, &project.Project{}, &testFindingIDs)
+			got := svc.NotificationAlert(context.Background(), c.alertCondition, c.alert, &[]model.AlertRule{}, &project.Project{}, &testFindingIDs, true)
 			if (got != nil && !c.wantErr) || (got == nil && c.wantErr) {
 				t.Fatalf("Unexpected error: %+v", got)
 			}


### PR DESCRIPTION
アラートの通知タイミングを以下の仕様・制御に変更したい。
- 新規のアラートは通知する
- アラートの内容に変更があった（Findingの内容が変更された）場合は通知する
- 上記以外にリマインダーとして一定期間経過で通知する
  - 前回通知からCacheSecond以降のタイミングでリマインド通知を行う
  - CacheSecondはデフォルト一ヶ月の値に設定する（WEB側の登録APIのパラメータを修正予定）
  - CasheSecondはユーザ側で変更可能とする