### PR TITLE
multi language slack notification

### DIFF
--- a/main.go
+++ b/main.go
@@ -25,10 +25,10 @@ type AppConf struct {
 	TraceDebug      bool     `split_words:"true" default:"false"`
 
 	// service
-	MaxAnalyzeAPICall  int64  `split_words:"true" default:"10"`
-	BaseURL            string `split_words:"true" default:"http://localhost"`
-	OpenAIToken        string `split_words:"true"`
-	NotificationLocale string `split_words:"true" default:"en"`
+	MaxAnalyzeAPICall int64  `split_words:"true" default:"10"`
+	BaseURL           string `split_words:"true" default:"http://localhost"`
+	OpenAIToken       string `split_words:"true"`
+	DefaultLocale     string `split_words:"true" default:"en"`
 
 	// db
 	DBMasterHost     string `split_words:"true" default:"db.middleware.svc.cluster.local"`
@@ -97,7 +97,7 @@ func main() {
 	if err != nil {
 		logger.Fatalf(ctx, "failed to create database client: %w", err)
 	}
-	c := server.NewConfig(conf.MaxAnalyzeAPICall, conf.BaseURL, conf.OpenAIToken, conf.NotificationLocale)
+	c := server.NewConfig(conf.MaxAnalyzeAPICall, conf.BaseURL, conf.OpenAIToken, conf.DefaultLocale)
 	server := server.NewServer("0.0.0.0", conf.Port, db, logger, c)
 
 	err = server.Run(ctx)

--- a/main.go
+++ b/main.go
@@ -25,9 +25,10 @@ type AppConf struct {
 	TraceDebug      bool     `split_words:"true" default:"false"`
 
 	// service
-	MaxAnalyzeAPICall int64  `split_words:"true" default:"10"`
-	BaseURL           string `split_words:"true" default:"http://localhost"`
-	OpenAIToken       string `split_words:"true"`
+	MaxAnalyzeAPICall  int64  `split_words:"true" default:"10"`
+	BaseURL            string `split_words:"true" default:"http://localhost"`
+	OpenAIToken        string `split_words:"true"`
+	NotificationLocale string `split_words:"true" default:"en"`
 
 	// db
 	DBMasterHost     string `split_words:"true" default:"db.middleware.svc.cluster.local"`
@@ -96,7 +97,7 @@ func main() {
 	if err != nil {
 		logger.Fatalf(ctx, "failed to create database client: %w", err)
 	}
-	c := server.NewConfig(conf.MaxAnalyzeAPICall, conf.BaseURL, conf.OpenAIToken)
+	c := server.NewConfig(conf.MaxAnalyzeAPICall, conf.BaseURL, conf.OpenAIToken, conf.NotificationLocale)
 	server := server.NewServer("0.0.0.0", conf.Port, db, logger, c)
 
 	err = server.Run(ctx)

--- a/pkg/server/alert/alert_analyze.go
+++ b/pkg/server/alert/alert_analyze.go
@@ -333,7 +333,7 @@ func (a *AlertService) NotificationAlert(
 		}
 		switch notification.Type {
 		case "slack":
-			err = sendSlackNotification(ctx, a.baseURL, notification.NotifySetting, alert, project, rules, findings)
+			err = sendSlackNotification(ctx, a.baseURL, notification.NotifySetting, alert, project, rules, findings, a.notificationLocale)
 			if err != nil {
 				return fmt.Errorf("notify error: notification_id=%d, err=%w", notification.NotificationID, err)
 			}

--- a/pkg/server/alert/alert_analyze.go
+++ b/pkg/server/alert/alert_analyze.go
@@ -333,7 +333,7 @@ func (a *AlertService) NotificationAlert(
 		}
 		switch notification.Type {
 		case "slack":
-			err = sendSlackNotification(ctx, a.baseURL, notification.NotifySetting, alert, project, rules, findings, a.notificationLocale)
+			err = sendSlackNotification(ctx, a.baseURL, notification.NotifySetting, alert, project, rules, findings, a.defaultLocale)
 			if err != nil {
 				return fmt.Errorf("notify error: notification_id=%d, err=%w", notification.NotificationID, err)
 			}

--- a/pkg/server/alert/alert_notification_test.go
+++ b/pkg/server/alert/alert_notification_test.go
@@ -287,13 +287,13 @@ func TestPutNotification(t *testing.T) {
 		{
 			name:       "OK Insert",
 			input:      &alert.PutNotificationRequest{Notification: &alert.NotificationForUpsert{ProjectId: 1001, Name: "name", Type: "slack", NotifySetting: `{"webhook_url": "https://example.com"}`}},
-			want:       &alert.PutNotificationResponse{Notification: &alert.Notification{ProjectId: 1001, Name: "name", Type: "slack", NotifySetting: `{"webhook_url":"https://e**********","data":{}}`, CreatedAt: now.Unix(), UpdatedAt: now.Unix()}},
+			want:       &alert.PutNotificationResponse{Notification: &alert.Notification{ProjectId: 1001, Name: "name", Type: "slack", NotifySetting: `{"webhook_url":"https://e**********","data":{},"locale":""}`, CreatedAt: now.Unix(), UpdatedAt: now.Unix()}},
 			mockUpResp: &model.Notification{ProjectID: 1001, Name: "name", Type: "slack", NotifySetting: `{"webhook_url": "https://example.com"}`, CreatedAt: now, UpdatedAt: now},
 		},
 		{
 			name:        "OK Update",
 			input:       &alert.PutNotificationRequest{Notification: &alert.NotificationForUpsert{NotificationId: 1001, ProjectId: 1001, Name: "name", Type: "slack", NotifySetting: `{"webhook_url": "https://example.com"}`}},
-			want:        &alert.PutNotificationResponse{Notification: &alert.Notification{NotificationId: 1001, ProjectId: 1001, Name: "name", Type: "slack", NotifySetting: `{"webhook_url":"https://e**********","data":{}}`, CreatedAt: now.Unix(), UpdatedAt: now.Unix()}},
+			want:        &alert.PutNotificationResponse{Notification: &alert.Notification{NotificationId: 1001, ProjectId: 1001, Name: "name", Type: "slack", NotifySetting: `{"webhook_url":"https://e**********","data":{},"locale":""}`, CreatedAt: now.Unix(), UpdatedAt: now.Unix()}},
 			mockGetResp: &model.Notification{NotificationID: 1001, ProjectID: 1001, Name: "name", Type: "slack", NotifySetting: `{"webhook_url": "https://example.com"}`, CreatedAt: now, UpdatedAt: now},
 			mockUpResp:  &model.Notification{NotificationID: 1001, ProjectID: 1001, Name: "name", Type: "slack", NotifySetting: `{"webhook_url": "https://example.com"}`, CreatedAt: now, UpdatedAt: now},
 		},

--- a/pkg/server/alert/alert_slack_test.go
+++ b/pkg/server/alert/alert_slack_test.go
@@ -55,7 +55,7 @@ func TestSendSlackNotification(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			got := sendSlackNotification(context.Background(), "unused", c.notifySetting, c.alert, c.project, &[]model.AlertRule{}, testFindings)
+			got := sendSlackNotification(context.Background(), "unused", c.notifySetting, c.alert, c.project, &[]model.AlertRule{}, testFindings, LocaleEn)
 			if (got != nil && !c.wantErr) || (got == nil && c.wantErr) {
 				t.Fatalf("Unexpected error: %+v", got)
 			}

--- a/pkg/server/alert/service.go
+++ b/pkg/server/alert/service.go
@@ -11,12 +11,13 @@ import (
 var _ alert.AlertServiceServer = (*AlertService)(nil)
 
 type AlertService struct {
-	repository        db.AlertRepository
-	findingClient     finding.FindingServiceClient
-	projectClient     project.ProjectServiceClient
-	maxAnalyzeAPICall int64
-	baseURL           string
-	logger            logging.Logger
+	repository         db.AlertRepository
+	findingClient      finding.FindingServiceClient
+	projectClient      project.ProjectServiceClient
+	maxAnalyzeAPICall  int64
+	baseURL            string
+	logger             logging.Logger
+	notificationLocale string
 }
 
 func NewAlertService(
@@ -26,13 +27,15 @@ func NewAlertService(
 	projectClient project.ProjectServiceClient,
 	repository db.AlertRepository,
 	logger logging.Logger,
+	notificationLocale string,
 ) *AlertService {
 	return &AlertService{
-		repository:        repository,
-		findingClient:     findingClient,
-		projectClient:     projectClient,
-		maxAnalyzeAPICall: maxAnalyzeAPICall,
-		baseURL:           baseURL,
-		logger:            logger,
+		repository:         repository,
+		findingClient:      findingClient,
+		projectClient:      projectClient,
+		maxAnalyzeAPICall:  maxAnalyzeAPICall,
+		baseURL:            baseURL,
+		logger:             logger,
+		notificationLocale: notificationLocale,
 	}
 }

--- a/pkg/server/alert/service.go
+++ b/pkg/server/alert/service.go
@@ -11,13 +11,13 @@ import (
 var _ alert.AlertServiceServer = (*AlertService)(nil)
 
 type AlertService struct {
-	repository         db.AlertRepository
-	findingClient      finding.FindingServiceClient
-	projectClient      project.ProjectServiceClient
-	maxAnalyzeAPICall  int64
-	baseURL            string
-	logger             logging.Logger
-	notificationLocale string
+	repository        db.AlertRepository
+	findingClient     finding.FindingServiceClient
+	projectClient     project.ProjectServiceClient
+	maxAnalyzeAPICall int64
+	baseURL           string
+	logger            logging.Logger
+	defaultLocale     string
 }
 
 func NewAlertService(
@@ -27,15 +27,15 @@ func NewAlertService(
 	projectClient project.ProjectServiceClient,
 	repository db.AlertRepository,
 	logger logging.Logger,
-	notificationLocale string,
+	defaultLocale string,
 ) *AlertService {
 	return &AlertService{
-		repository:         repository,
-		findingClient:      findingClient,
-		projectClient:      projectClient,
-		maxAnalyzeAPICall:  maxAnalyzeAPICall,
-		baseURL:            baseURL,
-		logger:             logger,
-		notificationLocale: notificationLocale,
+		repository:        repository,
+		findingClient:     findingClient,
+		projectClient:     projectClient,
+		maxAnalyzeAPICall: maxAnalyzeAPICall,
+		baseURL:           baseURL,
+		logger:            logger,
+		defaultLocale:     defaultLocale,
 	}
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -51,18 +51,18 @@ func NewServer(host string, port string, db *db.Client, logger logging.Logger, c
 }
 
 type Config struct {
-	MaxAnalyzeAPICall  int64
-	BaseURL            string
-	OpenAIToken        string
-	NotificationLocale string
+	MaxAnalyzeAPICall int64
+	BaseURL           string
+	OpenAIToken       string
+	defaultLocale     string
 }
 
-func NewConfig(maxAnalyzeAPICall int64, baseURL, openaiToken, NotificationLocale string) Config {
+func NewConfig(maxAnalyzeAPICall int64, baseURL, openaiToken, defaultLocale string) Config {
 	return Config{
-		MaxAnalyzeAPICall:  maxAnalyzeAPICall,
-		BaseURL:            baseURL,
-		OpenAIToken:        openaiToken,
-		NotificationLocale: NotificationLocale,
+		MaxAnalyzeAPICall: maxAnalyzeAPICall,
+		BaseURL:           baseURL,
+		OpenAIToken:       openaiToken,
+		defaultLocale:     defaultLocale,
 	}
 }
 
@@ -88,7 +88,7 @@ func (s *Server) Run(ctx context.Context) error {
 		pc,
 		s.db,
 		s.logger,
-		s.config.NotificationLocale,
+		s.config.defaultLocale,
 	)
 	fsvc := findingserver.NewFindingService(s.db, s.config.OpenAIToken, s.logger)
 	psvc := projectserver.NewProjectService(s.db, iamc, s.logger)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -51,16 +51,18 @@ func NewServer(host string, port string, db *db.Client, logger logging.Logger, c
 }
 
 type Config struct {
-	MaxAnalyzeAPICall int64
-	BaseURL           string
-	OpenAIToken       string
+	MaxAnalyzeAPICall  int64
+	BaseURL            string
+	OpenAIToken        string
+	NotificationLocale string
 }
 
-func NewConfig(maxAnalyzeAPICall int64, baseURL, openaiToken string) Config {
+func NewConfig(maxAnalyzeAPICall int64, baseURL, openaiToken, NotificationLocale string) Config {
 	return Config{
-		MaxAnalyzeAPICall: maxAnalyzeAPICall,
-		BaseURL:           baseURL,
-		OpenAIToken:       openaiToken,
+		MaxAnalyzeAPICall:  maxAnalyzeAPICall,
+		BaseURL:            baseURL,
+		OpenAIToken:        openaiToken,
+		NotificationLocale: NotificationLocale,
 	}
 }
 
@@ -86,6 +88,7 @@ func (s *Server) Run(ctx context.Context) error {
 		pc,
 		s.db,
 		s.logger,
+		s.config.NotificationLocale,
 	)
 	fsvc := findingserver.NewFindingService(s.db, s.config.OpenAIToken, s.logger)
 	psvc := projectserver.NewProjectService(s.db, iamc, s.logger)


### PR DESCRIPTION
Slack通知に英語/日本語の二つの言語を使用できるよう修正します
デフォルトで使用する言語は環境変数で受け取り、デフォルト値は英語です
notificationのnotify_settingのjsonにlocaleを追加して、そこに`ja`/`en`の指定がある場合はその言語を使用します

以下は補足です
- upsert時のlocaleのバリデーションはしてません
  - 異常値の場合にはデフォルト値を使うため問題ないと判断しました
  - Web画面では、選択式もしくは自動で入力するためユーザーのミスで異常値が入ることは想定していません
  - (意図的に異常値を入れることは可能ですが)
