### PR TITLE
fix webhook_url validation

### DIFF
--- a/proto/alert/validator.go
+++ b/proto/alert/validator.go
@@ -435,7 +435,10 @@ type slackNotifySetting struct {
 }
 
 func validateNewNotifySetting(value interface{}) error {
-	s, _ := value.(string)
+	s, ok := value.(string)
+	if !ok {
+		return fmt.Errorf("notify setting is not string, %v", value)
+	}
 	var setting slackNotifySetting
 	if err := json.Unmarshal([]byte(s), &setting); err != nil {
 		return fmt.Errorf("invalid json, %w", err)
@@ -451,7 +454,10 @@ func validateNewNotifySetting(value interface{}) error {
 }
 
 func validateExistingNotifySetting(value interface{}) error {
-	s, _ := value.(string)
+	s, ok := value.(string)
+	if !ok {
+		return fmt.Errorf("notify setting is not string, %v", value)
+	}
 	var setting slackNotifySetting
 	if err := json.Unmarshal([]byte(s), &setting); err != nil {
 		return fmt.Errorf("invalid json, %w", err)

--- a/proto/alert/validator_entity_test.go
+++ b/proto/alert/validator_entity_test.go
@@ -365,6 +365,11 @@ func TestValidateNotificationForUpsert(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name:    "OK not required notify webhook url (existing notification)",
+			input:   &NotificationForUpsert{NotificationId: 1, ProjectId: 1001, Name: "test_name", Type: "test_type", NotifySetting: `{"webhook_url": ""}`},
+			wantErr: false,
+		},
+		{
 			name:    "NG invalid notify webhook url",
 			input:   &NotificationForUpsert{ProjectId: 1001, Name: "test_name", Type: "test_type", NotifySetting: `{"webhook_url": "hoge"}`},
 			wantErr: true,

--- a/proto/alert/validator_test.go
+++ b/proto/alert/validator_test.go
@@ -1308,3 +1308,86 @@ func TestValidateAnalyzeAlertRequest(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateNewNotifySetting(t *testing.T) {
+	cases := []struct {
+		name    string
+		input   interface{}
+		wantErr bool
+	}{
+		{
+			name:    "OK",
+			input:   "{\"data\": {},\"locale\": \"en\",\"webhook_url\": \"https://hogehoge\"}",
+			wantErr: false,
+		},
+		{
+			name:    "NG input is not string",
+			input:   123,
+			wantErr: true,
+		},
+		{
+			name:    "NG invalid json",
+			input:   "invalid json",
+			wantErr: true,
+		},
+		{
+			name:    "NG required webhook_url",
+			input:   "{\"data\": {},\"locale\": \"en\"}",
+			wantErr: true,
+		},
+		{
+			name:    "NG invalid webhook_url",
+			input:   "{\"data\": {},\"locale\": \"en\",\"webhook_url\": \"invalid url\"}",
+			wantErr: true,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := validateNewNotifySetting(c.input)
+			if c.wantErr && err == nil {
+				t.Fatal("unexpected no error")
+			} else if !c.wantErr && err != nil {
+				t.Fatalf("Unexpected error occured: wantErr=%t, err=%+v", c.wantErr, err)
+			}
+		})
+	}
+}
+
+func TestValidateExistingNotifySetting(t *testing.T) {
+	cases := []struct {
+		name    string
+		input   interface{}
+		wantErr bool
+	}{
+		{
+			name:    "OK",
+			input:   "{\"data\": {},\"locale\": \"en\",\"webhook_url\": \"https://hogehoge\"}",
+			wantErr: false,
+		},
+		{
+			name:    "NG input is not string",
+			input:   123,
+			wantErr: true,
+		},
+		{
+			name:    "NG invalid json",
+			input:   "invalid json",
+			wantErr: true,
+		},
+		{
+			name:    "NG invalid webhook_url",
+			input:   "{\"data\": {},\"locale\": \"en\",\"webhook_url\": \"invalid url\"}",
+			wantErr: true,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := validateExistingNotifySetting(c.input)
+			if c.wantErr && err == nil {
+				t.Fatal("unexpected no error")
+			} else if !c.wantErr && err != nil {
+				t.Fatalf("Unexpected error occured: wantErr=%t, err=%+v", c.wantErr, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
WebhookURLのバリデーションを修正します

登録済みのWebhookURLはList,Get時にマスクして表示しています。(プロジェクト内の人が誰でもみれる状況を防ぐ)
これによりWebでは、マスク処理されたURLのみを見ることができるようになっています。
ユーザーがURLを再度確認しにいく作業をなくすために、PutNotificationで登録済みnotificationの更新時にWebhookURLを空にすれば既存の値を適用するようにしていました

現状のバリデーションでは、WebhookURL以外の値の更新時にエラーとなるため上記の目的を満たせなていないことに気づきました

そのため、Notificationの新規作成・更新時に処理を分けるようにします
新規作成時は既存のバリデーション、更新時はWebhookURLが空なのを許容し、存在している場合にはURL形式か検証します