### PR TITLE
fix put alert first viewed

### DIFF
--- a/pkg/server/alert/alert.go
+++ b/pkg/server/alert/alert.go
@@ -169,7 +169,6 @@ func (a *AlertService) PutAlertFirstViewedAt(ctx context.Context, req *alert.Put
 		if err != nil {
 			return nil, err
 		}
-
 	}
 
 	return &empty.Empty{}, nil

--- a/pkg/server/alert/alert.go
+++ b/pkg/server/alert/alert.go
@@ -143,19 +143,33 @@ func (a *AlertService) PutAlertFirstViewedAt(ctx context.Context, req *alert.Put
 
 	// Alertの存在チェック
 	// 存在して、FirstViewedAtが0でない場合は終了
-	savedData, err := a.repository.GetAlert(ctx, req.ProjectId, req.AlertId)
+	alerts, err := a.repository.ListAlert(ctx, req.ProjectId, nil, nil, "", 0, time.Now().Unix())
 	if err != nil {
 		return nil, err
 	}
-	if savedData.FirstViewedAt != nil && !savedData.FirstViewedAt.IsZero() {
+	putAlertIDs := []uint32{}
+	for _, alert := range *alerts {
+		if req.AlertId != 0 && alert.AlertID != req.AlertId {
+			continue
+		}
+		if alert.FirstViewedAt != nil && !alert.FirstViewedAt.IsZero() {
+			continue
+		}
+		putAlertIDs = append(putAlertIDs, alert.AlertID)
+	}
+	if len(putAlertIDs) == 0 {
 		return &empty.Empty{}, nil
 	}
+
 	unixTime := time.Now().Unix()
 
 	// Fiding upsert
-	err = a.repository.UpdateAlertFirstViewedAt(ctx, req.ProjectId, req.AlertId, unixTime)
-	if err != nil {
-		return nil, err
+	for _, alertID := range putAlertIDs {
+		err = a.repository.UpdateAlertFirstViewedAt(ctx, req.ProjectId, alertID, unixTime)
+		if err != nil {
+			return nil, err
+		}
+
 	}
 
 	return &empty.Empty{}, nil

--- a/pkg/server/alert/alert_test.go
+++ b/pkg/server/alert/alert_test.go
@@ -221,24 +221,24 @@ func TestPutAlertFirstViewedAt(t *testing.T) {
 	now := time.Now()
 
 	cases := []struct {
-		name        string
-		input       *alert.PutAlertFirstViewedAtRequest
-		wantErr     bool
-		mockGetResp *model.Alert
-		mockGetErr  error
-		callUpdate  bool
-		mockUpErr   error
+		name         string
+		input        *alert.PutAlertFirstViewedAtRequest
+		wantErr      bool
+		mockListResp *[]model.Alert
+		mockListErr  error
+		callUpdate   bool
+		mockUpErr    error
 	}{
 		{
-			name:        "OK",
-			input:       &alert.PutAlertFirstViewedAtRequest{ProjectId: 1001, AlertId: 1001},
-			mockGetResp: &model.Alert{AlertID: 1001, ProjectID: 1001, AlertConditionID: 1001, Description: "desc", Severity: "high", Status: "ACTIVE", CreatedAt: now, UpdatedAt: now},
-			callUpdate:  true,
+			name:         "OK",
+			input:        &alert.PutAlertFirstViewedAtRequest{ProjectId: 1001, AlertId: 1001},
+			mockListResp: &[]model.Alert{{AlertID: 1001, ProjectID: 1001, AlertConditionID: 1001, Description: "desc", Severity: "high", Status: "ACTIVE", CreatedAt: now, UpdatedAt: now}},
+			callUpdate:   true,
 		},
 		{
-			name:        "OK Already set",
-			input:       &alert.PutAlertFirstViewedAtRequest{ProjectId: 1001, AlertId: 1001},
-			mockGetResp: &model.Alert{AlertID: 1001, ProjectID: 1001, AlertConditionID: 1001, Description: "desc", Severity: "high", Status: "ACTIVE", CreatedAt: now, UpdatedAt: now, FirstViewedAt: &now},
+			name:         "OK Already set",
+			input:        &alert.PutAlertFirstViewedAtRequest{ProjectId: 1001, AlertId: 1001},
+			mockListResp: &[]model.Alert{{AlertID: 1001, ProjectID: 1001, AlertConditionID: 1001, Description: "desc", Severity: "high", Status: "ACTIVE", CreatedAt: now, UpdatedAt: now, FirstViewedAt: &now}},
 		},
 		{
 			name:    "NG Validation Error",
@@ -246,26 +246,26 @@ func TestPutAlertFirstViewedAt(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name:       "NG GetAlert Error",
-			input:      &alert.PutAlertFirstViewedAtRequest{ProjectId: 1001, AlertId: 1001},
-			mockGetErr: errors.New("something error"),
-			wantErr:    true,
+			name:        "NG GetAlert Error",
+			input:       &alert.PutAlertFirstViewedAtRequest{ProjectId: 1001, AlertId: 1001},
+			mockListErr: errors.New("something error"),
+			wantErr:     true,
 		},
 		{
-			name:        "NG Update Error",
-			input:       &alert.PutAlertFirstViewedAtRequest{ProjectId: 1001, AlertId: 1001},
-			mockGetResp: &model.Alert{AlertID: 1001, ProjectID: 1001, AlertConditionID: 1001, Description: "desc", Severity: "high", Status: "ACTIVE", CreatedAt: now, UpdatedAt: now},
-			callUpdate:  true,
-			mockUpErr:   errors.New("something error"),
-			wantErr:     true,
+			name:         "NG Update Error",
+			input:        &alert.PutAlertFirstViewedAtRequest{ProjectId: 1001, AlertId: 1001},
+			mockListResp: &[]model.Alert{{AlertID: 1001, ProjectID: 1001, AlertConditionID: 1001, Description: "desc", Severity: "high", Status: "ACTIVE", CreatedAt: now, UpdatedAt: now}},
+			callUpdate:   true,
+			mockUpErr:    errors.New("something error"),
+			wantErr:      true,
 		},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			mockDB := mocks.NewAlertRepository(t)
 			svc := AlertService{repository: mockDB, logger: logging.NewLogger()}
-			if c.mockGetResp != nil || c.mockGetErr != nil {
-				mockDB.On("GetAlert", test.RepeatMockAnything(3)...).Return(c.mockGetResp, c.mockGetErr).Once()
+			if c.mockListResp != nil || c.mockListErr != nil {
+				mockDB.On("ListAlert", test.RepeatMockAnything(7)...).Return(c.mockListResp, c.mockListErr).Once()
 			}
 			if c.callUpdate {
 				mockDB.On("UpdateAlertFirstViewedAt", test.RepeatMockAnything(4)...).Return(c.mockUpErr).Once()

--- a/proto/alert/validator.go
+++ b/proto/alert/validator.go
@@ -46,7 +46,6 @@ func (r *PutAlertRequest) Validate() error {
 func (r *PutAlertFirstViewedAtRequest) Validate() error {
 	return validation.ValidateStruct(r,
 		validation.Field(&r.ProjectId, validation.Required),
-		validation.Field(&r.AlertId, validation.Required),
 	)
 }
 

--- a/proto/alert/validator_test.go
+++ b/proto/alert/validator_test.go
@@ -150,11 +150,6 @@ func TestValidatePutAlertFirstViewedAtRequest(t *testing.T) {
 			input:   &PutAlertFirstViewedAtRequest{AlertId: 1001},
 			wantErr: true,
 		},
-		{
-			name:    "NG Required(alert_id)",
-			input:   &PutAlertFirstViewedAtRequest{ProjectId: 1001},
-			wantErr: true,
-		},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {


### PR DESCRIPTION
AlertのFirstViewed更新をより正確に計測するために以下の変更を行います
- AlertIDを必須から任意へ変更
  - AlertIDが含まれない場合は、該当プロジェクトのAlertを一括で更新する
  - AlertIDが含まれる場合は、該当のAlertのみ