### PR TITLE
chore: delete http endpoint

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -143,25 +143,6 @@ func (s *Server) Run(ctx context.Context) error {
 	return nil
 }
 
-func healthCheck(ctx context.Context, addr string) error {
-	conn, err := getGRPCConn(context.Background(), addr)
-	if err != nil {
-		return err
-	}
-	defer conn.Close()
-
-	client := grpc_health_v1.NewHealthClient(conn)
-	res, err := client.Check(ctx, &grpc_health_v1.HealthCheckRequest{})
-	if err != nil {
-		return err
-	}
-	if res.Status != grpc_health_v1.HealthCheckResponse_SERVING {
-		return fmt.Errorf("returned status is '%v'", res.Status)
-	}
-
-	return nil
-}
-
 func (s *Server) newFindingClient(svcAddr string) (finding.FindingServiceClient, error) {
 	ctx := context.Background()
 	conn, err := getGRPCConn(ctx, svcAddr)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net"
-	"net/http"
 	"os"
 	"os/signal"
 	"syscall"
@@ -126,23 +125,6 @@ func (s *Server) Run(ctx context.Context) error {
 	go func() {
 		if err := server.Serve(l); err != nil && err != grpc.ErrServerStopped {
 			s.logger.Errorf(ctx, "failed to serve grpc: %w", err)
-			errChan <- err
-		}
-	}()
-
-	mux := http.NewServeMux()
-	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
-		if err := healthCheck(ctx, clientAddr); err != nil {
-			w.WriteHeader(http.StatusServiceUnavailable)
-			s.logger.Errorf(ctx, "health check is failed: %w", err)
-		} else {
-			fmt.Fprintln(w, "ok")
-		}
-	})
-
-	go func() {
-		if err := http.ListenAndServe(fmt.Sprintf("%s:3000", s.host), mux); err != http.ErrServerClosed {
-			s.logger.Errorf(ctx, "failed to start http server: %w", err)
 			errChan <- err
 		}
 	}()


### PR DESCRIPTION
# 概要
grpc_probeが使えるようになったため、readiness probeのために作成していたHTTPヘルスチェックエンドポイントを削除します。

# チェックポイント
- 余計なものを削除していないか

# 参考資料
https://kubernetes.io/blog/2022/05/13/grpc-probes-now-in-beta/
https://github.com/ca-risken/internal-community/issues/615
