### PR TITLE
fix removing exist data

### DIFF
--- a/pkg/server/alert/alert_notification.go
+++ b/pkg/server/alert/alert_notification.go
@@ -167,7 +167,12 @@ func (a *AlertService) replaceSlackNotifySetting(ctx context.Context, jsonNotify
 			return slackNotifySetting{}, err
 		}
 	}
-	if !zero.IsZeroVal(notifySettingUpdate.WebhookURL) {
+	if notifySettingUpdate.WebhookURL != "" {
+		notifySettingUpdate.ChannelID = ""
+		return notifySettingUpdate, nil
+	}
+	if notifySettingUpdate.ChannelID != "" {
+		notifySettingUpdate.Data = slackNotifyOption{}
 		return notifySettingUpdate, nil
 	}
 	notifySettingUpdate.WebhookURL = notifySettingExist.WebhookURL


### PR DESCRIPTION
Notificationに既存データが存在する際の更新時の挙動を変更します。
#### 変更前
webhookurl設定済み、またはChannelID設定済みの時
=> 新たに設定したものが追加され、どちらの設定も残る

#### 変更後
webhookurl設定済みの時、ChannelID指定
=> 既存のwebhookurlの設定が解除され、ChannelIDが設定される
ChannelID設定済みの時、webhookurl指定
=> 既存のChannelIDの設定が解除され、webhookurlが設定される
webhookurl設定済みの時、channelid,webhookurlどちらも新たに設定しない
=> 既存のwebhookurlが残る