### PR TITLE
add put-alert-first-viewed-at

### DIFF
--- a/pkg/server/project/project.go
+++ b/pkg/server/project/project.go
@@ -117,8 +117,9 @@ func (p *ProjectService) createDefaultRole(ctx context.Context, ownerUserID, pro
 	projectAdmin := "project-admin"
 	projectViewer := "project-viewer"
 	findingEditor := "finding-editor"
+	viewerActionPtn := "get|list|is-admin|put-alert-first-viewed-at"
 
-	for name, actionPtn := range map[string]string{projectAdmin: ".*", projectViewer: "/finding/.+", findingEditor: "get|list|is-admin|/finding/.+"} {
+	for name, actionPtn := range map[string]string{projectAdmin: ".*", projectViewer: viewerActionPtn, findingEditor: viewerActionPtn + "|/finding/.+"} {
 		policy, err := p.iamClient.PutPolicy(ctx, &iam.PutPolicyRequest{
 			ProjectId: projectID,
 			Policy: &iam.PolicyForUpsert{

--- a/pkg/server/project/project.go
+++ b/pkg/server/project/project.go
@@ -119,7 +119,7 @@ func (p *ProjectService) createDefaultRole(ctx context.Context, ownerUserID, pro
 	findingEditor := "finding-editor"
 	viewerActionPtn := "get|list|is-admin|put-alert-first-viewed-at"
 
-	for name, actionPtn := range map[string]string{projectAdmin: ".*", projectViewer: viewerActionPtn, findingEditor: viewerActionPtn + "|/finding/.+"} {
+	for name, actionPtn := range map[string]string{projectAdmin: ".*", projectViewer: viewerActionPtn, findingEditor: viewerActionPtn + "|/finding/.+|/alert/.+"} {
 		policy, err := p.iamClient.PutPolicy(ctx, &iam.PutPolicyRequest{
 			ProjectId: projectID,
 			Policy: &iam.PolicyForUpsert{


### PR DESCRIPTION
put-alert-first-viewed-atの権限がないと、alertとfindingの画面を開くことができなかったので修正しました。また、viewer権限が間違っていたので修正しました。

動作確認済み
<img width="1038" alt="image" src="https://github.com/ca-risken/core/assets/44151180/265e560c-4ce2-4543-b580-41c93b780ddf">

実際にfindingが開くことが可能かどうかはローカルで管理者以外のユーザーを作成してそれにログインする方法がわからなかったため、試せていません。方法をご存知でしたらご教示ください。
