### PR TITLE
add get user request parameter

### DIFF
--- a/pkg/db/mocks/IAMRepository.go
+++ b/pkg/db/mocks/IAMRepository.go
@@ -490,25 +490,25 @@ func (_m *IAMRepository) GetTokenPolicy(ctx context.Context, accessTokenID uint3
 	return r0, r1
 }
 
-// GetUser provides a mock function with given fields: ctx, userID, sub
-func (_m *IAMRepository) GetUser(ctx context.Context, userID uint32, sub string) (*model.User, error) {
-	ret := _m.Called(ctx, userID, sub)
+// GetUser provides a mock function with given fields: ctx, userID, sub, userIdpKey
+func (_m *IAMRepository) GetUser(ctx context.Context, userID uint32, sub string, userIdpKey string) (*model.User, error) {
+	ret := _m.Called(ctx, userID, sub, userIdpKey)
 
 	var r0 *model.User
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, uint32, string) (*model.User, error)); ok {
-		return rf(ctx, userID, sub)
+	if rf, ok := ret.Get(0).(func(context.Context, uint32, string, string) (*model.User, error)); ok {
+		return rf(ctx, userID, sub, userIdpKey)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, uint32, string) *model.User); ok {
-		r0 = rf(ctx, userID, sub)
+	if rf, ok := ret.Get(0).(func(context.Context, uint32, string, string) *model.User); ok {
+		r0 = rf(ctx, userID, sub, userIdpKey)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*model.User)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, uint32, string) error); ok {
-		r1 = rf(ctx, userID, sub)
+	if rf, ok := ret.Get(1).(func(context.Context, uint32, string, string) error); ok {
+		r1 = rf(ctx, userID, sub, userIdpKey)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/pkg/server/iam/user.go
+++ b/pkg/server/iam/user.go
@@ -31,7 +31,7 @@ func (i *IAMService) GetUser(ctx context.Context, req *iam.GetUserRequest) (*iam
 	if err := req.Validate(); err != nil {
 		return nil, err
 	}
-	user, err := i.repository.GetUser(ctx, req.UserId, req.Sub)
+	user, err := i.repository.GetUser(ctx, req.UserId, req.Sub, req.UserIdpKey)
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			i.logger.Infof(ctx, "[GetUser]User not found: GetUserRequest=%+v", req)

--- a/pkg/server/iam/user_test.go
+++ b/pkg/server/iam/user_test.go
@@ -113,7 +113,7 @@ func TestGetUser(t *testing.T) {
 			svc := IAMService{repository: mock, logger: logging.NewLogger()}
 
 			if c.mockResponce != nil || c.mockError != nil {
-				mock.On("GetUser", test.RepeatMockAnything(3)...).Return(c.mockResponce, c.mockError).Once()
+				mock.On("GetUser", test.RepeatMockAnything(4)...).Return(c.mockResponce, c.mockError).Once()
 			}
 			got, err := svc.GetUser(ctx, c.input)
 			if err != nil && !c.wantErr {

--- a/proto/iam/validator.go
+++ b/proto/iam/validator.go
@@ -19,8 +19,9 @@ func (l *ListUserRequest) Validate() error {
 // Validate GetUserRequest
 func (g *GetUserRequest) Validate() error {
 	return validation.ValidateStruct(g,
-		validation.Field(&g.UserId, validation.When(zero.IsZeroVal(g.Sub), validation.Required.Error("UserId or Sub is required."))),
-		validation.Field(&g.Sub, validation.When(zero.IsZeroVal(g.UserId), validation.Required.Error("UserId or Sub is required."))),
+		validation.Field(&g.UserId, validation.When(zero.IsZeroVal(g.Sub) && g.UserIdpKey == "", validation.Required.Error("UserId or Sub or UserIdpKey is required."))),
+		validation.Field(&g.Sub, validation.When(zero.IsZeroVal(g.UserId) && g.UserIdpKey == "", validation.Required.Error("UserId or Sub or UserIdpKey is required."))),
+		validation.Field(&g.UserIdpKey, validation.When(zero.IsZeroVal(g.UserId) && g.Sub == "", validation.Required.Error("UserId or Sub or UserIdpKey is required."))),
 	)
 }
 

--- a/proto/iam/validator.go
+++ b/proto/iam/validator.go
@@ -17,10 +17,11 @@ func (l *ListUserRequest) Validate() error {
 
 // Validate GetUserRequest
 func (g *GetUserRequest) Validate() error {
+	errMsg := "UserId or Sub or UserIdpKey is required."
 	return validation.ValidateStruct(g,
-		validation.Field(&g.UserId, validation.When(g.Sub == "" && g.UserIdpKey == "", validation.Required.Error("UserId or Sub or UserIdpKey is required."))),
-		validation.Field(&g.Sub, validation.When(g.UserId == 0 && g.UserIdpKey == "", validation.Required.Error("UserId or Sub or UserIdpKey is required."))),
-		validation.Field(&g.UserIdpKey, validation.When(g.UserId == 0 && g.Sub == "", validation.Required.Error("UserId or Sub or UserIdpKey is required."))),
+		validation.Field(&g.UserId, validation.When(g.Sub == "" && g.UserIdpKey == "", validation.Required.Error(errMsg))),
+		validation.Field(&g.Sub, validation.When(g.UserId == 0 && g.UserIdpKey == "", validation.Required.Error(errMsg))),
+		validation.Field(&g.UserIdpKey, validation.When(g.UserId == 0 && g.Sub == "", validation.Required.Error(errMsg))),
 	)
 }
 

--- a/proto/iam/validator.go
+++ b/proto/iam/validator.go
@@ -6,7 +6,6 @@ import (
 	"regexp"
 
 	validation "github.com/go-ozzo/ozzo-validation/v4"
-	"github.com/vikyd/zero"
 )
 
 // Validate ListUserRequest
@@ -19,9 +18,9 @@ func (l *ListUserRequest) Validate() error {
 // Validate GetUserRequest
 func (g *GetUserRequest) Validate() error {
 	return validation.ValidateStruct(g,
-		validation.Field(&g.UserId, validation.When(zero.IsZeroVal(g.Sub) && g.UserIdpKey == "", validation.Required.Error("UserId or Sub or UserIdpKey is required."))),
-		validation.Field(&g.Sub, validation.When(zero.IsZeroVal(g.UserId) && g.UserIdpKey == "", validation.Required.Error("UserId or Sub or UserIdpKey is required."))),
-		validation.Field(&g.UserIdpKey, validation.When(zero.IsZeroVal(g.UserId) && g.Sub == "", validation.Required.Error("UserId or Sub or UserIdpKey is required."))),
+		validation.Field(&g.UserId, validation.When(g.Sub == "" && g.UserIdpKey == "", validation.Required.Error("UserId or Sub or UserIdpKey is required."))),
+		validation.Field(&g.Sub, validation.When(g.UserId == 0 && g.UserIdpKey == "", validation.Required.Error("UserId or Sub or UserIdpKey is required."))),
+		validation.Field(&g.UserIdpKey, validation.When(g.UserId == 0 && g.Sub == "", validation.Required.Error("UserId or Sub or UserIdpKey is required."))),
 	)
 }
 


### PR DESCRIPTION
GetUserのリクエストにて、UserIdpKeyでの検索を可能にします
protoのリクエストパラメータとしては用意されてましたが、validator,dbがuser_idp_keyに対応していなかったので修正
validatorはuser_id,subのどちらかが必須からuser_id,sub,user_idp_keyのどれかが必須に変更しました。