### PR TITLE
Fix admin bug

### DIFF
--- a/pkg/db/iam.go
+++ b/pkg/db/iam.go
@@ -364,7 +364,7 @@ func (c *Client) DetachRole(ctx context.Context, projectID, roleID, userID uint3
 			"not found user or role: user_id=%d, role_id=%d, project_id=%d", userID, roleID, projectID)
 	}
 	if zero.IsZeroVal(projectID) {
-		return c.Master.WithContext(ctx).Exec(deleteDetachAdminRole, userID, roleID, projectID).Error
+		return c.Master.WithContext(ctx).Exec(deleteDetachAdminRole, userID, roleID).Error
 	} else {
 		return c.Master.WithContext(ctx).Exec(deleteDetachProjectRole, userID, roleID, projectID).Error
 	}

--- a/pkg/server/alert/alert_notification_test.go
+++ b/pkg/server/alert/alert_notification_test.go
@@ -332,6 +332,12 @@ func TestPutNotification(t *testing.T) {
 }
 
 func TestRequestProjectRoleNotification(t *testing.T) {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+	// External HTTP mock for slack notification
+	httpmock.RegisterResponder("POST", "https://example.com",
+		httpmock.NewStringResponder(200, "ok"))
+
 	var ctx context.Context
 	type mockListNotification struct {
 		Resp *[]model.Notification
@@ -360,7 +366,14 @@ func TestRequestProjectRoleNotification(t *testing.T) {
 			wantErr: false,
 			listNotification: mockListNotification{
 				Resp: &[]model.Notification{
-					{ProjectID: 1001, Name: "name", Type: "slack", NotifySetting: `{"webhook_url": "https://example.com"}`, CreatedAt: now, UpdatedAt: now},
+					{
+						ProjectID:     1001,
+						Name:          "name",
+						Type:          "slack",
+						NotifySetting: `{"webhook_url": "https://example.com"}`,
+						CreatedAt:     now,
+						UpdatedAt:     now,
+					},
 				},
 				Err: nil,
 			},


### PR DESCRIPTION
AdminAPI経由でロール更新が失敗する問題を修正します。
また、Slack関連のテストが失敗してた箇所があったのですが、外部へのHTTPリクエストはmock化してテスト通る形に修正しています