### PR TITLE
fix: get policy

### DIFF
--- a/pkg/db/organization_iam.go
+++ b/pkg/db/organization_iam.go
@@ -54,8 +54,10 @@ func (c *Client) ListOrganizationRole(ctx context.Context, organizationID uint32
 	return data, nil
 }
 
+const getOrganizationRole = `select * from organization_role r where role_id = ?`
+
 func (c *Client) GetOrganizationRole(ctx context.Context, organizationID, roleID uint32) (*model.OrganizationRole, error) {
-	query := `select * from organization_role r where role_id = ?`
+	query := getOrganizationRole
 	var params []interface{}
 	params = append(params, roleID)
 	if organizationID != 0 {

--- a/pkg/db/organization_iam_test.go
+++ b/pkg/db/organization_iam_test.go
@@ -132,7 +132,7 @@ func TestGetOrganizationRole(t *testing.T) {
 			want:    &model.OrganizationRole{RoleID: 1, OrganizationID: 1, Name: "role1", CreatedAt: now, UpdatedAt: now},
 			wantErr: false,
 			mockClosure: func(mock sqlmock.Sqlmock) {
-				mock.ExpectQuery(regexp.QuoteMeta("select * from organization_role r where role_id =? and r.organization_id = ?")).WillReturnRows(sqlmock.NewRows([]string{
+				mock.ExpectQuery(regexp.QuoteMeta("select * from organization_role r where role_id = ? and r.organization_id = ?")).WillReturnRows(sqlmock.NewRows([]string{
 					"role_id", "organization_id", "name", "created_at", "updated_at"}).
 					AddRow(uint32(1), uint32(1), "role1", now, now))
 			},
@@ -143,7 +143,7 @@ func TestGetOrganizationRole(t *testing.T) {
 			want:    nil,
 			wantErr: true,
 			mockClosure: func(mock sqlmock.Sqlmock) {
-				mock.ExpectQuery(regexp.QuoteMeta("select * from organization_role r where role_id =? and r.organization_id = ?")).WillReturnError(errors.New("DB error"))
+				mock.ExpectQuery(regexp.QuoteMeta("select * from organization_role r where role_id = ? and r.organization_id = ?")).WillReturnError(errors.New("DB error"))
 			},
 		},
 	}
@@ -738,14 +738,14 @@ func TestAttachOrganizationRole(t *testing.T) {
 			want:    &model.OrganizationRole{RoleID: 1, OrganizationID: 1, Name: "role1", CreatedAt: now, UpdatedAt: now},
 			wantErr: false,
 			mockClosure: func(mock sqlmock.Sqlmock) {
-				mock.ExpectQuery(regexp.QuoteMeta("select * from organization_role r where role_id =?")).WillReturnRows(sqlmock.NewRows([]string{
+				mock.ExpectQuery(regexp.QuoteMeta("select * from organization_role r where role_id = ?")).WillReturnRows(sqlmock.NewRows([]string{
 					"role_id", "organization_id", "name", "created_at", "updated_at"}).
 					AddRow(uint32(1), uint32(1), "role1", now, now))
 				mock.ExpectQuery(regexp.QuoteMeta("select * from user where activated = 'true' and user_id = ?")).WillReturnRows(sqlmock.NewRows([]string{
 					"user_id", "sub", "name", "user_idp_key", "activated", "created_at", "updated_at"}).
 					AddRow(uint32(1), "sub1", "user1", "key1", true, now, now))
 				mock.ExpectExec(regexp.QuoteMeta(insertAttachOrganizationRole)).WillReturnResult(sqlmock.NewResult(1, 1))
-				mock.ExpectQuery(regexp.QuoteMeta("select * from organization_role r where role_id =?")).WillReturnRows(sqlmock.NewRows([]string{
+				mock.ExpectQuery(regexp.QuoteMeta("select * from organization_role r where role_id = ?")).WillReturnRows(sqlmock.NewRows([]string{
 					"role_id", "organization_id", "name", "created_at", "updated_at"}).
 					AddRow(uint32(1), uint32(1), "role1", now, now))
 			},
@@ -756,7 +756,7 @@ func TestAttachOrganizationRole(t *testing.T) {
 			want:    nil,
 			wantErr: true,
 			mockClosure: func(mock sqlmock.Sqlmock) {
-				mock.ExpectQuery(regexp.QuoteMeta("select * from organization_role r where role_id =?")).WillReturnRows(sqlmock.NewRows([]string{
+				mock.ExpectQuery(regexp.QuoteMeta("select * from organization_role r where role_id = ?")).WillReturnRows(sqlmock.NewRows([]string{
 					"role_id", "organization_id", "name", "created_at", "updated_at"}).
 					AddRow(uint32(1), uint32(1), "role1", now, now))
 				mock.ExpectQuery(regexp.QuoteMeta("select * from user where activated = 'true' and user_id = ?")).WillReturnRows(sqlmock.NewRows([]string{
@@ -771,14 +771,14 @@ func TestAttachOrganizationRole(t *testing.T) {
 			want:    nil,
 			wantErr: true,
 			mockClosure: func(mock sqlmock.Sqlmock) {
-				mock.ExpectQuery(regexp.QuoteMeta("select * from organization_role r where role_id =?")).WillReturnRows(sqlmock.NewRows([]string{
+				mock.ExpectQuery(regexp.QuoteMeta("select * from organization_role r where role_id = ?")).WillReturnRows(sqlmock.NewRows([]string{
 					"role_id", "organization_id", "name", "created_at", "updated_at"}).
 					AddRow(uint32(1), uint32(1), "role1", now, now))
 				mock.ExpectQuery(regexp.QuoteMeta("select * from user where activated = 'true' and user_id = ?")).WillReturnRows(sqlmock.NewRows([]string{
 					"user_id", "sub", "name", "user_idp_key", "activated", "created_at", "updated_at"}).
 					AddRow(uint32(1), "sub1", "user1", "key1", true, now, now))
 				mock.ExpectExec(regexp.QuoteMeta(insertAttachOrganizationRole)).WillReturnResult(sqlmock.NewResult(1, 1))
-				mock.ExpectQuery(regexp.QuoteMeta("select * from organization_role r where role_id =?")).WillReturnError(errors.New("DB error"))
+				mock.ExpectQuery(regexp.QuoteMeta("select * from organization_role r where role_id = ?")).WillReturnError(errors.New("DB error"))
 			},
 		},
 		{
@@ -787,7 +787,7 @@ func TestAttachOrganizationRole(t *testing.T) {
 			want:    nil,
 			wantErr: true,
 			mockClosure: func(mock sqlmock.Sqlmock) {
-				mock.ExpectQuery(regexp.QuoteMeta("select * from organization_role r where role_id =?")).WillReturnError(gorm.ErrRecordNotFound)
+				mock.ExpectQuery(regexp.QuoteMeta("select * from organization_role r where role_id = ?")).WillReturnError(gorm.ErrRecordNotFound)
 			},
 		},
 		{
@@ -796,7 +796,7 @@ func TestAttachOrganizationRole(t *testing.T) {
 			want:    nil,
 			wantErr: true,
 			mockClosure: func(mock sqlmock.Sqlmock) {
-				mock.ExpectQuery(regexp.QuoteMeta("select * from organization_role r where role_id =?")).WillReturnRows(sqlmock.NewRows([]string{
+				mock.ExpectQuery(regexp.QuoteMeta("select * from organization_role r where role_id = ?")).WillReturnRows(sqlmock.NewRows([]string{
 					"role_id", "organization_id", "name", "created_at", "updated_at"}).
 					AddRow(uint32(1), uint32(1), "role1", now, now))
 				mock.ExpectQuery(regexp.QuoteMeta("select * from user where activated = 'true' and user_id = ?")).WillReturnError(gorm.ErrRecordNotFound)
@@ -842,7 +842,7 @@ func TestDetachOrganizationRole(t *testing.T) {
 			args:    args{roleID: 1, userID: 1},
 			wantErr: false,
 			mockClosure: func(mock sqlmock.Sqlmock) {
-				mock.ExpectQuery(regexp.QuoteMeta("select * from organization_role r where role_id =?")).WillReturnRows(sqlmock.NewRows([]string{
+				mock.ExpectQuery(regexp.QuoteMeta("select * from organization_role r where role_id = ?")).WillReturnRows(sqlmock.NewRows([]string{
 					"role_id", "organization_id", "name", "created_at", "updated_at"}).
 					AddRow(uint32(1), uint32(1), "role1", now, now))
 				mock.ExpectQuery(regexp.QuoteMeta("select * from user where activated = 'true' and user_id = ?")).WillReturnRows(sqlmock.NewRows([]string{
@@ -856,7 +856,7 @@ func TestDetachOrganizationRole(t *testing.T) {
 			args:    args{roleID: 1, userID: 1},
 			wantErr: true,
 			mockClosure: func(mock sqlmock.Sqlmock) {
-				mock.ExpectQuery(regexp.QuoteMeta("select * from organization_role r where role_id =?")).WillReturnRows(sqlmock.NewRows([]string{
+				mock.ExpectQuery(regexp.QuoteMeta("select * from organization_role r where role_id = ?")).WillReturnRows(sqlmock.NewRows([]string{
 					"role_id", "organization_id", "name", "created_at", "updated_at"}).
 					AddRow(uint32(1), uint32(1), "role1", now, now))
 				mock.ExpectQuery(regexp.QuoteMeta("select * from user where activated = 'true' and user_id = ?")).WillReturnRows(sqlmock.NewRows([]string{
@@ -904,7 +904,7 @@ func TestAttachOrganizationPolicy(t *testing.T) {
 			want:    &model.OrganizationPolicy{PolicyID: 1, OrganizationID: 1, Name: "policy1", CreatedAt: now, UpdatedAt: now},
 			wantErr: false,
 			mockClosure: func(mock sqlmock.Sqlmock) {
-				mock.ExpectQuery(regexp.QuoteMeta("select * from organization_role r where role_id =?")).WillReturnRows(sqlmock.NewRows([]string{
+				mock.ExpectQuery(regexp.QuoteMeta("select * from organization_role r where role_id = ?")).WillReturnRows(sqlmock.NewRows([]string{
 					"role_id", "organization_id", "name", "created_at", "updated_at"}).
 					AddRow(uint32(1), uint32(1), "role1", now, now))
 				mock.ExpectQuery(regexp.QuoteMeta(getOrganizationPolicy)).WillReturnRows(sqlmock.NewRows([]string{
@@ -922,7 +922,7 @@ func TestAttachOrganizationPolicy(t *testing.T) {
 			want:    nil,
 			wantErr: true,
 			mockClosure: func(mock sqlmock.Sqlmock) {
-				mock.ExpectQuery(regexp.QuoteMeta("select * from organization_role r where role_id =?")).WillReturnRows(sqlmock.NewRows([]string{
+				mock.ExpectQuery(regexp.QuoteMeta("select * from organization_role r where role_id = ?")).WillReturnRows(sqlmock.NewRows([]string{
 					"role_id", "organization_id", "name", "created_at", "updated_at"}).
 					AddRow(uint32(1), uint32(1), "role1", now, now))
 				mock.ExpectQuery(regexp.QuoteMeta(getOrganizationPolicy)).WillReturnRows(sqlmock.NewRows([]string{
@@ -937,7 +937,7 @@ func TestAttachOrganizationPolicy(t *testing.T) {
 			want:    nil,
 			wantErr: true,
 			mockClosure: func(mock sqlmock.Sqlmock) {
-				mock.ExpectQuery(regexp.QuoteMeta("select * from organization_role r where role_id =?")).WillReturnRows(sqlmock.NewRows([]string{
+				mock.ExpectQuery(regexp.QuoteMeta("select * from organization_role r where role_id = ?")).WillReturnRows(sqlmock.NewRows([]string{
 					"role_id", "organization_id", "name", "created_at", "updated_at"}).
 					AddRow(uint32(1), uint32(1), "role1", now, now))
 				mock.ExpectQuery(regexp.QuoteMeta(getOrganizationPolicy)).WillReturnRows(sqlmock.NewRows([]string{
@@ -953,7 +953,7 @@ func TestAttachOrganizationPolicy(t *testing.T) {
 			want:    nil,
 			wantErr: true,
 			mockClosure: func(mock sqlmock.Sqlmock) {
-				mock.ExpectQuery(regexp.QuoteMeta("select * from organization_role r where role_id =?")).WillReturnError(gorm.ErrRecordNotFound)
+				mock.ExpectQuery(regexp.QuoteMeta("select * from organization_role r where role_id = ?")).WillReturnError(gorm.ErrRecordNotFound)
 			},
 		},
 		{
@@ -962,7 +962,7 @@ func TestAttachOrganizationPolicy(t *testing.T) {
 			want:    nil,
 			wantErr: true,
 			mockClosure: func(mock sqlmock.Sqlmock) {
-				mock.ExpectQuery(regexp.QuoteMeta("select * from organization_role r where role_id =?")).WillReturnRows(sqlmock.NewRows([]string{
+				mock.ExpectQuery(regexp.QuoteMeta("select * from organization_role r where role_id = ?")).WillReturnRows(sqlmock.NewRows([]string{
 					"role_id", "organization_id", "name", "created_at", "updated_at"}).
 					AddRow(uint32(1), uint32(1), "role1", now, now))
 				mock.ExpectQuery(regexp.QuoteMeta(getOrganizationPolicy)).WillReturnError(gorm.ErrRecordNotFound)
@@ -1008,7 +1008,7 @@ func TestDetachOrganizationPolicy(t *testing.T) {
 			args:    args{roleID: 1, policyID: 1},
 			wantErr: false,
 			mockClosure: func(mock sqlmock.Sqlmock) {
-				mock.ExpectQuery(regexp.QuoteMeta("select * from organization_role r where role_id =?")).WillReturnRows(sqlmock.NewRows([]string{
+				mock.ExpectQuery(regexp.QuoteMeta("select * from organization_role r where role_id = ?")).WillReturnRows(sqlmock.NewRows([]string{
 					"role_id", "organization_id", "name", "created_at", "updated_at"}).
 					AddRow(uint32(1), uint32(1), "role1", now, now))
 				mock.ExpectQuery(regexp.QuoteMeta(getOrganizationPolicy)).WillReturnRows(sqlmock.NewRows([]string{
@@ -1022,7 +1022,7 @@ func TestDetachOrganizationPolicy(t *testing.T) {
 			args:    args{roleID: 1, policyID: 1},
 			wantErr: true,
 			mockClosure: func(mock sqlmock.Sqlmock) {
-				mock.ExpectQuery(regexp.QuoteMeta("select * from organization_role r where role_id =?")).WillReturnRows(sqlmock.NewRows([]string{
+				mock.ExpectQuery(regexp.QuoteMeta("select * from organization_role r where role_id = ?")).WillReturnRows(sqlmock.NewRows([]string{
 					"role_id", "organization_id", "name", "created_at", "updated_at"}).
 					AddRow(uint32(1), uint32(1), "role1", now, now))
 				mock.ExpectQuery(regexp.QuoteMeta(getOrganizationPolicy)).WillReturnRows(sqlmock.NewRows([]string{

--- a/pkg/db/organization_iam_test.go
+++ b/pkg/db/organization_iam_test.go
@@ -738,14 +738,14 @@ func TestAttachOrganizationRole(t *testing.T) {
 			want:    &model.OrganizationRole{RoleID: 1, OrganizationID: 1, Name: "role1", CreatedAt: now, UpdatedAt: now},
 			wantErr: false,
 			mockClosure: func(mock sqlmock.Sqlmock) {
-				mock.ExpectQuery(regexp.QuoteMeta("select * from organization_role r where role_id = ?")).WillReturnRows(sqlmock.NewRows([]string{
+				mock.ExpectQuery(regexp.QuoteMeta(getOrganizationRole)).WillReturnRows(sqlmock.NewRows([]string{
 					"role_id", "organization_id", "name", "created_at", "updated_at"}).
 					AddRow(uint32(1), uint32(1), "role1", now, now))
 				mock.ExpectQuery(regexp.QuoteMeta("select * from user where activated = 'true' and user_id = ?")).WillReturnRows(sqlmock.NewRows([]string{
 					"user_id", "sub", "name", "user_idp_key", "activated", "created_at", "updated_at"}).
 					AddRow(uint32(1), "sub1", "user1", "key1", true, now, now))
 				mock.ExpectExec(regexp.QuoteMeta(insertAttachOrganizationRole)).WillReturnResult(sqlmock.NewResult(1, 1))
-				mock.ExpectQuery(regexp.QuoteMeta("select * from organization_role r where role_id = ?")).WillReturnRows(sqlmock.NewRows([]string{
+				mock.ExpectQuery(regexp.QuoteMeta(getOrganizationRole)).WillReturnRows(sqlmock.NewRows([]string{
 					"role_id", "organization_id", "name", "created_at", "updated_at"}).
 					AddRow(uint32(1), uint32(1), "role1", now, now))
 			},
@@ -756,7 +756,7 @@ func TestAttachOrganizationRole(t *testing.T) {
 			want:    nil,
 			wantErr: true,
 			mockClosure: func(mock sqlmock.Sqlmock) {
-				mock.ExpectQuery(regexp.QuoteMeta("select * from organization_role r where role_id = ?")).WillReturnRows(sqlmock.NewRows([]string{
+				mock.ExpectQuery(regexp.QuoteMeta(getOrganizationRole)).WillReturnRows(sqlmock.NewRows([]string{
 					"role_id", "organization_id", "name", "created_at", "updated_at"}).
 					AddRow(uint32(1), uint32(1), "role1", now, now))
 				mock.ExpectQuery(regexp.QuoteMeta("select * from user where activated = 'true' and user_id = ?")).WillReturnRows(sqlmock.NewRows([]string{
@@ -771,14 +771,14 @@ func TestAttachOrganizationRole(t *testing.T) {
 			want:    nil,
 			wantErr: true,
 			mockClosure: func(mock sqlmock.Sqlmock) {
-				mock.ExpectQuery(regexp.QuoteMeta("select * from organization_role r where role_id = ?")).WillReturnRows(sqlmock.NewRows([]string{
+				mock.ExpectQuery(regexp.QuoteMeta(getOrganizationRole)).WillReturnRows(sqlmock.NewRows([]string{
 					"role_id", "organization_id", "name", "created_at", "updated_at"}).
 					AddRow(uint32(1), uint32(1), "role1", now, now))
 				mock.ExpectQuery(regexp.QuoteMeta("select * from user where activated = 'true' and user_id = ?")).WillReturnRows(sqlmock.NewRows([]string{
 					"user_id", "sub", "name", "user_idp_key", "activated", "created_at", "updated_at"}).
 					AddRow(uint32(1), "sub1", "user1", "key1", true, now, now))
 				mock.ExpectExec(regexp.QuoteMeta(insertAttachOrganizationRole)).WillReturnResult(sqlmock.NewResult(1, 1))
-				mock.ExpectQuery(regexp.QuoteMeta("select * from organization_role r where role_id = ?")).WillReturnError(errors.New("DB error"))
+				mock.ExpectQuery(regexp.QuoteMeta(getOrganizationRole)).WillReturnError(errors.New("DB error"))
 			},
 		},
 		{
@@ -787,7 +787,7 @@ func TestAttachOrganizationRole(t *testing.T) {
 			want:    nil,
 			wantErr: true,
 			mockClosure: func(mock sqlmock.Sqlmock) {
-				mock.ExpectQuery(regexp.QuoteMeta("select * from organization_role r where role_id = ?")).WillReturnError(gorm.ErrRecordNotFound)
+				mock.ExpectQuery(regexp.QuoteMeta(getOrganizationRole)).WillReturnError(gorm.ErrRecordNotFound)
 			},
 		},
 		{
@@ -796,7 +796,7 @@ func TestAttachOrganizationRole(t *testing.T) {
 			want:    nil,
 			wantErr: true,
 			mockClosure: func(mock sqlmock.Sqlmock) {
-				mock.ExpectQuery(regexp.QuoteMeta("select * from organization_role r where role_id = ?")).WillReturnRows(sqlmock.NewRows([]string{
+				mock.ExpectQuery(regexp.QuoteMeta(getOrganizationRole)).WillReturnRows(sqlmock.NewRows([]string{
 					"role_id", "organization_id", "name", "created_at", "updated_at"}).
 					AddRow(uint32(1), uint32(1), "role1", now, now))
 				mock.ExpectQuery(regexp.QuoteMeta("select * from user where activated = 'true' and user_id = ?")).WillReturnError(gorm.ErrRecordNotFound)

--- a/pkg/db/organization_iam_test.go
+++ b/pkg/db/organization_iam_test.go
@@ -842,7 +842,7 @@ func TestDetachOrganizationRole(t *testing.T) {
 			args:    args{roleID: 1, userID: 1},
 			wantErr: false,
 			mockClosure: func(mock sqlmock.Sqlmock) {
-				mock.ExpectQuery(regexp.QuoteMeta("select * from organization_role r where role_id = ?")).WillReturnRows(sqlmock.NewRows([]string{
+				mock.ExpectQuery(regexp.QuoteMeta(getOrganizationRole)).WillReturnRows(sqlmock.NewRows([]string{
 					"role_id", "organization_id", "name", "created_at", "updated_at"}).
 					AddRow(uint32(1), uint32(1), "role1", now, now))
 				mock.ExpectQuery(regexp.QuoteMeta("select * from user where activated = 'true' and user_id = ?")).WillReturnRows(sqlmock.NewRows([]string{
@@ -856,7 +856,7 @@ func TestDetachOrganizationRole(t *testing.T) {
 			args:    args{roleID: 1, userID: 1},
 			wantErr: true,
 			mockClosure: func(mock sqlmock.Sqlmock) {
-				mock.ExpectQuery(regexp.QuoteMeta("select * from organization_role r where role_id = ?")).WillReturnRows(sqlmock.NewRows([]string{
+				mock.ExpectQuery(regexp.QuoteMeta(getOrganizationRole)).WillReturnRows(sqlmock.NewRows([]string{
 					"role_id", "organization_id", "name", "created_at", "updated_at"}).
 					AddRow(uint32(1), uint32(1), "role1", now, now))
 				mock.ExpectQuery(regexp.QuoteMeta("select * from user where activated = 'true' and user_id = ?")).WillReturnRows(sqlmock.NewRows([]string{
@@ -904,7 +904,7 @@ func TestAttachOrganizationPolicy(t *testing.T) {
 			want:    &model.OrganizationPolicy{PolicyID: 1, OrganizationID: 1, Name: "policy1", CreatedAt: now, UpdatedAt: now},
 			wantErr: false,
 			mockClosure: func(mock sqlmock.Sqlmock) {
-				mock.ExpectQuery(regexp.QuoteMeta("select * from organization_role r where role_id = ?")).WillReturnRows(sqlmock.NewRows([]string{
+				mock.ExpectQuery(regexp.QuoteMeta(getOrganizationRole)).WillReturnRows(sqlmock.NewRows([]string{
 					"role_id", "organization_id", "name", "created_at", "updated_at"}).
 					AddRow(uint32(1), uint32(1), "role1", now, now))
 				mock.ExpectQuery(regexp.QuoteMeta(getOrganizationPolicy)).WillReturnRows(sqlmock.NewRows([]string{
@@ -922,7 +922,7 @@ func TestAttachOrganizationPolicy(t *testing.T) {
 			want:    nil,
 			wantErr: true,
 			mockClosure: func(mock sqlmock.Sqlmock) {
-				mock.ExpectQuery(regexp.QuoteMeta("select * from organization_role r where role_id = ?")).WillReturnRows(sqlmock.NewRows([]string{
+				mock.ExpectQuery(regexp.QuoteMeta(getOrganizationRole)).WillReturnRows(sqlmock.NewRows([]string{
 					"role_id", "organization_id", "name", "created_at", "updated_at"}).
 					AddRow(uint32(1), uint32(1), "role1", now, now))
 				mock.ExpectQuery(regexp.QuoteMeta(getOrganizationPolicy)).WillReturnRows(sqlmock.NewRows([]string{
@@ -937,7 +937,7 @@ func TestAttachOrganizationPolicy(t *testing.T) {
 			want:    nil,
 			wantErr: true,
 			mockClosure: func(mock sqlmock.Sqlmock) {
-				mock.ExpectQuery(regexp.QuoteMeta("select * from organization_role r where role_id = ?")).WillReturnRows(sqlmock.NewRows([]string{
+				mock.ExpectQuery(regexp.QuoteMeta(getOrganizationRole)).WillReturnRows(sqlmock.NewRows([]string{
 					"role_id", "organization_id", "name", "created_at", "updated_at"}).
 					AddRow(uint32(1), uint32(1), "role1", now, now))
 				mock.ExpectQuery(regexp.QuoteMeta(getOrganizationPolicy)).WillReturnRows(sqlmock.NewRows([]string{
@@ -953,7 +953,7 @@ func TestAttachOrganizationPolicy(t *testing.T) {
 			want:    nil,
 			wantErr: true,
 			mockClosure: func(mock sqlmock.Sqlmock) {
-				mock.ExpectQuery(regexp.QuoteMeta("select * from organization_role r where role_id = ?")).WillReturnError(gorm.ErrRecordNotFound)
+				mock.ExpectQuery(regexp.QuoteMeta(getOrganizationRole)).WillReturnError(gorm.ErrRecordNotFound)
 			},
 		},
 		{
@@ -962,7 +962,7 @@ func TestAttachOrganizationPolicy(t *testing.T) {
 			want:    nil,
 			wantErr: true,
 			mockClosure: func(mock sqlmock.Sqlmock) {
-				mock.ExpectQuery(regexp.QuoteMeta("select * from organization_role r where role_id = ?")).WillReturnRows(sqlmock.NewRows([]string{
+				mock.ExpectQuery(regexp.QuoteMeta(getOrganizationRole)).WillReturnRows(sqlmock.NewRows([]string{
 					"role_id", "organization_id", "name", "created_at", "updated_at"}).
 					AddRow(uint32(1), uint32(1), "role1", now, now))
 				mock.ExpectQuery(regexp.QuoteMeta(getOrganizationPolicy)).WillReturnError(gorm.ErrRecordNotFound)
@@ -1008,7 +1008,7 @@ func TestDetachOrganizationPolicy(t *testing.T) {
 			args:    args{roleID: 1, policyID: 1},
 			wantErr: false,
 			mockClosure: func(mock sqlmock.Sqlmock) {
-				mock.ExpectQuery(regexp.QuoteMeta("select * from organization_role r where role_id = ?")).WillReturnRows(sqlmock.NewRows([]string{
+				mock.ExpectQuery(regexp.QuoteMeta(getOrganizationRole)).WillReturnRows(sqlmock.NewRows([]string{
 					"role_id", "organization_id", "name", "created_at", "updated_at"}).
 					AddRow(uint32(1), uint32(1), "role1", now, now))
 				mock.ExpectQuery(regexp.QuoteMeta(getOrganizationPolicy)).WillReturnRows(sqlmock.NewRows([]string{
@@ -1022,7 +1022,7 @@ func TestDetachOrganizationPolicy(t *testing.T) {
 			args:    args{roleID: 1, policyID: 1},
 			wantErr: true,
 			mockClosure: func(mock sqlmock.Sqlmock) {
-				mock.ExpectQuery(regexp.QuoteMeta("select * from organization_role r where role_id = ?")).WillReturnRows(sqlmock.NewRows([]string{
+				mock.ExpectQuery(regexp.QuoteMeta(getOrganizationRole)).WillReturnRows(sqlmock.NewRows([]string{
 					"role_id", "organization_id", "name", "created_at", "updated_at"}).
 					AddRow(uint32(1), uint32(1), "role1", now, now))
 				mock.ExpectQuery(regexp.QuoteMeta(getOrganizationPolicy)).WillReturnRows(sqlmock.NewRows([]string{

--- a/pkg/server/organization_iam/policy_test.go
+++ b/pkg/server/organization_iam/policy_test.go
@@ -83,8 +83,8 @@ func TestGetOrganizationPolicy(t *testing.T) {
 		{
 			name:         "OK",
 			input:        &organization_iam.GetOrganizationPolicyRequest{PolicyId: 111, OrganizationId: 123},
-			want:         &organization_iam.GetOrganizationPolicyResponse{Policy: &organization_iam.OrganizationPolicy{PolicyId: 111, Name: "nm", OrganizationId: 123, CreatedAt: now.Unix(), UpdatedAt: now.Unix()}},
-			mockResponce: &model.OrganizationPolicy{PolicyID: 111, Name: "nm", OrganizationID: 123, CreatedAt: now, UpdatedAt: now},
+			want:         &organization_iam.GetOrganizationPolicyResponse{Policy: &organization_iam.OrganizationPolicy{PolicyId: 111, Name: "nm", ActionPtn: ".*", OrganizationId: 123, CreatedAt: now.Unix(), UpdatedAt: now.Unix()}},
+			mockResponce: &model.OrganizationPolicy{PolicyID: 111, Name: "nm", ActionPtn: ".*", OrganizationID: 123, CreatedAt: now, UpdatedAt: now},
 		},
 		{
 			name:      "OK Record Not Found",
@@ -255,19 +255,21 @@ func TestAttachOrganizationPolicy(t *testing.T) {
 			},
 			want: &organization_iam.AttachOrganizationPolicyResponse{
 				Policy: &organization_iam.OrganizationPolicy{
-					PolicyId:  1,
-					Name:      "test-policy",
-					ActionPtn: "test:*",
-					CreatedAt: now.Unix(),
-					UpdatedAt: now.Unix(),
+					PolicyId:       1,
+					Name:           "test-policy",
+					ActionPtn:      "test:*",
+					OrganizationId: 1,
+					CreatedAt:      now.Unix(),
+					UpdatedAt:      now.Unix(),
 				},
 			},
 			mockResponse: &model.OrganizationPolicy{
-				PolicyID:  1,
-				Name:      "test-policy",
-				ActionPtn: "test:*",
-				CreatedAt: now,
-				UpdatedAt: now,
+				PolicyID:       1,
+				Name:           "test-policy",
+				ActionPtn:      "test:*",
+				OrganizationID: 1,
+				CreatedAt:      now,
+				UpdatedAt:      now,
 			},
 		},
 		{


### PR DESCRIPTION
GetOrganizationPolicyが意図しない挙動をするため、修正しました。
具体的にはOrganization IDが0の場合もwhere句にクエリを追加してしまうようになっていました。
他のいくつかのテストも修正を加えています。