### PR TITLE
support: prefix-match ressource name with finding setting

### DIFF
--- a/pkg/db/mocks/FindingRepository.go
+++ b/pkg/db/mocks/FindingRepository.go
@@ -438,36 +438,6 @@ func (_m *FindingRepository) GetFindingSetting(ctx context.Context, projectID ui
 	return r0, r1
 }
 
-// GetFindingSettingByResource provides a mock function with given fields: ctx, projectID, resourceName
-func (_m *FindingRepository) GetFindingSettingByResource(ctx context.Context, projectID uint32, resourceName string) (*model.FindingSetting, error) {
-	ret := _m.Called(ctx, projectID, resourceName)
-
-	if len(ret) == 0 {
-		panic("no return value specified for GetFindingSettingByResource")
-	}
-
-	var r0 *model.FindingSetting
-	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, uint32, string) (*model.FindingSetting, error)); ok {
-		return rf(ctx, projectID, resourceName)
-	}
-	if rf, ok := ret.Get(0).(func(context.Context, uint32, string) *model.FindingSetting); ok {
-		r0 = rf(ctx, projectID, resourceName)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*model.FindingSetting)
-		}
-	}
-
-	if rf, ok := ret.Get(1).(func(context.Context, uint32, string) error); ok {
-		r1 = rf(ctx, projectID, resourceName)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
 // GetFindingTagByKey provides a mock function with given fields: _a0, _a1, _a2, _a3
 func (_m *FindingRepository) GetFindingTagByKey(_a0 context.Context, _a1 uint32, _a2 uint64, _a3 string) (*model.FindingTag, error) {
 	ret := _m.Called(_a0, _a1, _a2, _a3)

--- a/pkg/server/finding/finding_batch_test.go
+++ b/pkg/server/finding/finding_batch_test.go
@@ -19,9 +19,9 @@ func TestPutFindingBatch(t *testing.T) {
 		GetFindingByDataSourceResp *model.Finding
 		GetFindingByDataSourceErr  error
 
-		GetFindingSettingByResourceCall bool
-		GetFindingSettingByResourceResp *model.FindingSetting
-		GetFindingSettingByResourceErr  error
+		GetListFindingSettingCall bool
+		GetListFindingSettingResp *[]model.FindingSetting
+		GetListFindingSettingErr  error
 
 		GetResourceByNameCall bool
 		GetResourceByNameResp *model.Resource
@@ -76,8 +76,8 @@ func TestPutFindingBatch(t *testing.T) {
 			mock: &mockResp{
 				GetFindingByDataSourceCall:       true,
 				GetFindingByDataSourceResp:       &model.Finding{FindingID: 1},
-				GetFindingSettingByResourceCall:  true,
-				GetFindingSettingByResourceResp:  &model.FindingSetting{},
+				GetListFindingSettingCall:        true,
+				GetListFindingSettingResp:        &[]model.FindingSetting{},
 				GetResourceByNameCall:            true,
 				GetResourceByNameResp:            &model.Resource{ResourceID: 1},
 				GetRecommendByDataSourceTypeCall: true,
@@ -106,12 +106,12 @@ func TestPutFindingBatch(t *testing.T) {
 			}},
 			wantErr: false,
 			mock: &mockResp{
-				GetFindingByDataSourceCall:      true,
-				GetFindingByDataSourceResp:      &model.Finding{FindingID: 1},
-				GetFindingSettingByResourceCall: true,
-				GetFindingSettingByResourceResp: &model.FindingSetting{},
-				GetResourceByNameCall:           true,
-				GetResourceByNameResp:           &model.Resource{ResourceID: 1},
+				GetFindingByDataSourceCall: true,
+				GetFindingByDataSourceResp: &model.Finding{FindingID: 1},
+				GetListFindingSettingCall:  true,
+				GetListFindingSettingResp:  &[]model.FindingSetting{},
+				GetResourceByNameCall:      true,
+				GetResourceByNameResp:      &model.Resource{ResourceID: 1},
 
 				BulkUpsertFindingCall:          true,
 				BulkUpsertResourceCall:         true,
@@ -158,8 +158,8 @@ func TestPutFindingBatch(t *testing.T) {
 			if c.mock.GetFindingByDataSourceCall {
 				mockDB.On("GetFindingByDataSource", test.RepeatMockAnything(4)...).Return(c.mock.GetFindingByDataSourceResp, c.mock.GetFindingByDataSourceErr).Once()
 			}
-			if c.mock.GetFindingSettingByResourceCall {
-				mockDB.On("GetFindingSettingByResource", test.RepeatMockAnything(3)...).Return(c.mock.GetFindingSettingByResourceResp, c.mock.GetFindingSettingByResourceErr).Once()
+			if c.mock.GetListFindingSettingCall {
+				mockDB.On("ListFindingSetting", test.RepeatMockAnything(3)...).Return(c.mock.GetListFindingSettingResp, c.mock.GetListFindingSettingErr).Once()
 			}
 			if c.mock.GetResourceByNameCall {
 				mockDB.On("GetResourceByName", test.RepeatMockAnything(3)...).Return(c.mock.GetResourceByNameResp, c.mock.GetResourceByNameErr).Once()

--- a/pkg/server/finding/finding_test.go
+++ b/pkg/server/finding/finding_test.go
@@ -174,56 +174,56 @@ func TestPutFinding(t *testing.T) {
 		mockUpResp  *model.Finding
 		mockUpErr   error
 
-		callGetFindingSettingByResource bool
-		callGetResourceByName           bool
-		callUpsertResource              bool
+		callListFindingSetting bool
+		callGetResourceByName  bool
+		callUpsertResource     bool
 	}{
 		{
-			name:                            "OK Insert",
-			input:                           &finding.PutFindingRequest{Finding: &finding.FindingForUpsert{DataSource: "ds", DataSourceId: "ds-001", ResourceName: "rn", OriginalScore: 100.00, OriginalMaxScore: 100.00}},
-			want:                            &finding.PutFindingResponse{Finding: &finding.Finding{FindingId: 1001, DataSource: "ds", DataSourceId: "ds-001", ResourceName: "rn", OriginalScore: 100.00, Score: 1.0, CreatedAt: now.Unix(), UpdatedAt: now.Unix()}},
-			mockGetErr:                      gorm.ErrRecordNotFound,
-			mockUpResp:                      &model.Finding{FindingID: 1001, DataSource: "ds", DataSourceID: "ds-001", ResourceName: "rn", OriginalScore: 100.00, Score: 1.0, CreatedAt: now, UpdatedAt: now},
-			callGetFindingSettingByResource: true,
-			callGetResourceByName:           true,
-			callUpsertResource:              true,
+			name:                   "OK Insert",
+			input:                  &finding.PutFindingRequest{Finding: &finding.FindingForUpsert{DataSource: "ds", DataSourceId: "ds-001", ResourceName: "rn", OriginalScore: 100.00, OriginalMaxScore: 100.00}},
+			want:                   &finding.PutFindingResponse{Finding: &finding.Finding{FindingId: 1001, DataSource: "ds", DataSourceId: "ds-001", ResourceName: "rn", OriginalScore: 100.00, Score: 1.0, CreatedAt: now.Unix(), UpdatedAt: now.Unix()}},
+			mockGetErr:             gorm.ErrRecordNotFound,
+			mockUpResp:             &model.Finding{FindingID: 1001, DataSource: "ds", DataSourceID: "ds-001", ResourceName: "rn", OriginalScore: 100.00, Score: 1.0, CreatedAt: now, UpdatedAt: now},
+			callListFindingSetting: true,
+			callGetResourceByName:  true,
+			callUpsertResource:     true,
 		},
 		{
-			name:                            "OK Update",
-			input:                           &finding.PutFindingRequest{Finding: &finding.FindingForUpsert{DataSource: "ds", DataSourceId: "ds-001", ResourceName: "rn", OriginalScore: 20.00, OriginalMaxScore: 100.00}},
-			want:                            &finding.PutFindingResponse{Finding: &finding.Finding{FindingId: 1001, DataSource: "ds", DataSourceId: "ds-001", ResourceName: "rn", OriginalScore: 20.00, Score: 0.2, CreatedAt: now.Unix(), UpdatedAt: now.Unix()}},
-			mockGetResp:                     &model.Finding{FindingID: 1001, DataSource: "ds", DataSourceID: "ds-001", ResourceName: "rn", OriginalScore: 10.00, Score: 0.1, CreatedAt: now, UpdatedAt: now},
-			mockUpResp:                      &model.Finding{FindingID: 1001, DataSource: "ds", DataSourceID: "ds-001", ResourceName: "rn", OriginalScore: 20.00, Score: 0.2, CreatedAt: now, UpdatedAt: now},
-			callGetFindingSettingByResource: true,
-			callGetResourceByName:           true,
-			callUpsertResource:              true,
+			name:                   "OK Update",
+			input:                  &finding.PutFindingRequest{Finding: &finding.FindingForUpsert{DataSource: "ds", DataSourceId: "ds-001", ResourceName: "rn", OriginalScore: 20.00, OriginalMaxScore: 100.00}},
+			want:                   &finding.PutFindingResponse{Finding: &finding.Finding{FindingId: 1001, DataSource: "ds", DataSourceId: "ds-001", ResourceName: "rn", OriginalScore: 20.00, Score: 0.2, CreatedAt: now.Unix(), UpdatedAt: now.Unix()}},
+			mockGetResp:            &model.Finding{FindingID: 1001, DataSource: "ds", DataSourceID: "ds-001", ResourceName: "rn", OriginalScore: 10.00, Score: 0.1, CreatedAt: now, UpdatedAt: now},
+			mockUpResp:             &model.Finding{FindingID: 1001, DataSource: "ds", DataSourceID: "ds-001", ResourceName: "rn", OriginalScore: 20.00, Score: 0.2, CreatedAt: now, UpdatedAt: now},
+			callListFindingSetting: true,
+			callGetResourceByName:  true,
+			callUpsertResource:     true,
 		},
 		{
-			name:                            "NG Invalid request(no data_source)",
-			input:                           &finding.PutFindingRequest{Finding: &finding.FindingForUpsert{DataSource: "", DataSourceId: "ds-001", ResourceName: "rn", OriginalScore: 100.00, OriginalMaxScore: 100.00}},
-			wantErr:                         true,
-			callGetFindingSettingByResource: false,
-			callGetResourceByName:           false,
-			callUpsertResource:              false,
+			name:                   "NG Invalid request(no data_source)",
+			input:                  &finding.PutFindingRequest{Finding: &finding.FindingForUpsert{DataSource: "", DataSourceId: "ds-001", ResourceName: "rn", OriginalScore: 100.00, OriginalMaxScore: 100.00}},
+			wantErr:                true,
+			callListFindingSetting: false,
+			callGetResourceByName:  false,
+			callUpsertResource:     false,
 		},
 		{
-			name:                            "NG GetFindingByDataSource error",
-			input:                           &finding.PutFindingRequest{Finding: &finding.FindingForUpsert{DataSource: "ds", DataSourceId: "ds-001", ResourceName: "rn", OriginalScore: 100.00, OriginalMaxScore: 100.00}},
-			wantErr:                         true,
-			mockGetErr:                      gorm.ErrInvalidDB,
-			callGetFindingSettingByResource: false,
-			callGetResourceByName:           false,
-			callUpsertResource:              false,
+			name:                   "NG GetFindingByDataSource error",
+			input:                  &finding.PutFindingRequest{Finding: &finding.FindingForUpsert{DataSource: "ds", DataSourceId: "ds-001", ResourceName: "rn", OriginalScore: 100.00, OriginalMaxScore: 100.00}},
+			wantErr:                true,
+			mockGetErr:             gorm.ErrInvalidDB,
+			callListFindingSetting: false,
+			callGetResourceByName:  false,
+			callUpsertResource:     false,
 		},
 		{
-			name:                            "NG UpsertFinding error",
-			input:                           &finding.PutFindingRequest{Finding: &finding.FindingForUpsert{DataSource: "ds", DataSourceId: "ds-001", ResourceName: "rn", OriginalScore: 100.00, OriginalMaxScore: 100.00}},
-			wantErr:                         true,
-			mockGetResp:                     &model.Finding{FindingID: 1001, DataSource: "ds", DataSourceID: "ds-001", ResourceName: "rn", OriginalScore: 10.00, Score: 0.1, CreatedAt: now, UpdatedAt: now},
-			mockUpErr:                       gorm.ErrInvalidDB,
-			callGetFindingSettingByResource: true,
-			callGetResourceByName:           false,
-			callUpsertResource:              false,
+			name:                   "NG UpsertFinding error",
+			input:                  &finding.PutFindingRequest{Finding: &finding.FindingForUpsert{DataSource: "ds", DataSourceId: "ds-001", ResourceName: "rn", OriginalScore: 100.00, OriginalMaxScore: 100.00}},
+			wantErr:                true,
+			mockGetResp:            &model.Finding{FindingID: 1001, DataSource: "ds", DataSourceID: "ds-001", ResourceName: "rn", OriginalScore: 10.00, Score: 0.1, CreatedAt: now, UpdatedAt: now},
+			mockUpErr:              gorm.ErrInvalidDB,
+			callListFindingSetting: true,
+			callGetResourceByName:  false,
+			callUpsertResource:     false,
 		},
 	}
 	for _, c := range cases {
@@ -237,8 +237,8 @@ func TestPutFinding(t *testing.T) {
 			if c.mockUpResp != nil || c.mockUpErr != nil {
 				mockDB.On("UpsertFinding", test.RepeatMockAnything(2)...).Return(c.mockUpResp, c.mockUpErr).Once()
 			}
-			if c.callGetFindingSettingByResource {
-				mockDB.On("GetFindingSettingByResource", test.RepeatMockAnything(3)...).Return(&model.FindingSetting{}, nil) // fixed response
+			if c.callListFindingSetting {
+				mockDB.On("ListFindingSetting", test.RepeatMockAnything(3)...).Return(&[]model.FindingSetting{{ResourceName: "rn", Setting: `{"score_coefficient": 0.1}`}}, nil) // fixed response
 			}
 			if c.callGetResourceByName {
 				mockDB.On("GetResourceByName", test.RepeatMockAnything(3)...).Return(&model.Resource{}, nil) // fixed response


### PR DESCRIPTION
FindingSettingにおいて、リソース名のPrefixマッチをサポートします
例えば、オートスケールされるKubernetesノードなどのケースでは以下の課題があります。

- 短命のノードに脆弱性があるケース
- ノードが生成されるたびにFindingが生成される
- リソース名が完全一致だと対象リソースのコントロールが難しい