### PR TITLE
refactor: implement deletion of organization invitations and projects

### DIFF
--- a/pkg/db/project.go
+++ b/pkg/db/project.go
@@ -181,17 +181,9 @@ func (c *Client) UntagProject(ctx context.Context, projectID uint32, tag string)
 	return nil
 }
 
-const deleteOrganizationInvitationByProject = `delete from organization_invitation where project_id=?`
-const deleteOrganizationProject = `delete from organization_project where project_id=?`
 const deleteProject = `delete from project where project_id=?`
 
 func (c *Client) DeleteProject(ctx context.Context, projectID uint32) error {
-	if err := c.Master.WithContext(ctx).Exec(deleteOrganizationInvitationByProject, projectID).Error; err != nil {
-		return err
-	}
-	if err := c.Master.WithContext(ctx).Exec(deleteOrganizationProject, projectID).Error; err != nil {
-		return err
-	}
 	if err := c.Master.WithContext(ctx).Exec(deleteProject, projectID).Error; err != nil {
 		return err
 	}
@@ -300,5 +292,14 @@ func (c *Client) CleanWithNoProject(ctx context.Context) error {
 	if err := c.Master.WithContext(ctx).Exec(fmt.Sprintf(cleanTableWithNoProjectTemplate, "project_tag"), projectIDs).Error; err != nil {
 		return err
 	}
+	
+	// organization
+	if err := c.Master.WithContext(ctx).Exec(fmt.Sprintf(cleanTableWithNoProjectTemplate, "organization_invitation"), projectIDs).Error; err != nil {
+		return err
+	}
+	if err := c.Master.WithContext(ctx).Exec(fmt.Sprintf(cleanTableWithNoProjectTemplate, "organization_project"), projectIDs).Error; err != nil {
+		return err
+	}
+	
 	return nil
 }

--- a/pkg/db/project.go
+++ b/pkg/db/project.go
@@ -181,9 +181,17 @@ func (c *Client) UntagProject(ctx context.Context, projectID uint32, tag string)
 	return nil
 }
 
+const deleteOrganizationInvitationByProject = `delete from organization_invitation where project_id=?`
+const deleteOrganizationProject = `delete from organization_project where project_id=?`
 const deleteProject = `delete from project where project_id=?`
 
 func (c *Client) DeleteProject(ctx context.Context, projectID uint32) error {
+	if err := c.Master.WithContext(ctx).Exec(deleteOrganizationInvitationByProject, projectID).Error; err != nil {
+		return err
+	}
+	if err := c.Master.WithContext(ctx).Exec(deleteOrganizationProject, projectID).Error; err != nil {
+		return err
+	}
 	if err := c.Master.WithContext(ctx).Exec(deleteProject, projectID).Error; err != nil {
 		return err
 	}

--- a/pkg/db/project_test.go
+++ b/pkg/db/project_test.go
@@ -39,10 +39,8 @@ func TestDeleteProject(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			ctx := context.Background()
 			if c.mockErr != nil {
-				mock.ExpectExec(deleteOrganizationInvitationByProject).WillReturnError(c.mockErr)
+				mock.ExpectExec(deleteProject).WillReturnError(c.mockErr)
 			} else {
-				mock.ExpectExec(deleteOrganizationInvitationByProject).WillReturnResult(sqlmock.NewResult(int64(1), int64(1)))
-				mock.ExpectExec(deleteOrganizationProject).WillReturnResult(sqlmock.NewResult(int64(1), int64(1)))
 				mock.ExpectExec(deleteProject).WillReturnResult(sqlmock.NewResult(int64(1), int64(1)))
 			}
 
@@ -99,6 +97,8 @@ func TestCleanWithNoProject(t *testing.T) {
 				"delete from policy where project_id in",
 				"delete from role_policy where project_id in",
 				"delete from project_tag where project_id in",
+				"delete from organization_invitation where project_id in",
+				"delete from organization_project where project_id in",
 			},
 			wantErr: false,
 		},

--- a/pkg/db/project_test.go
+++ b/pkg/db/project_test.go
@@ -39,8 +39,10 @@ func TestDeleteProject(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			ctx := context.Background()
 			if c.mockErr != nil {
-				mock.ExpectExec(deleteProject).WillReturnError(c.mockErr)
+				mock.ExpectExec(deleteOrganizationInvitationByProject).WillReturnError(c.mockErr)
 			} else {
+				mock.ExpectExec(deleteOrganizationInvitationByProject).WillReturnResult(sqlmock.NewResult(int64(1), int64(1)))
+				mock.ExpectExec(deleteOrganizationProject).WillReturnResult(sqlmock.NewResult(int64(1), int64(1)))
 				mock.ExpectExec(deleteProject).WillReturnResult(sqlmock.NewResult(int64(1), int64(1)))
 			}
 


### PR DESCRIPTION
プロジェクトが削除されたとき、Organization関連のエンティティを削除するため、cleanProjectの処理を追加します

## 動作確認
ローカルでmake clean-projectをした時

- Projectが削除されていない場合はOrgProejctとOrgInvitaitonは削除されない
- Projectが削除されている場合はOrgProejctとOrgInvitaitonは削除される

ことを確認しました