### PR TITLE
feat: add go-test target to Makefile and remove unused build options from GitHub Actions workflow

### DIFF
--- a/.github/workflows/build-pr-core.yml
+++ b/.github/workflows/build-pr-core.yml
@@ -13,8 +13,6 @@ jobs:
       install_go_version: "1.23.3"
       golangci_lint_version: "v1.62.0"
       image_prefix: "risken-core"
-      build_opt: "--no-cache --pull"
-      test_command: "test"
       aws_xray_sdk_disabled: "true"
     secrets:
       DOCKER_USER: ${{ secrets.DOCKER_USER }}

--- a/Makefile
+++ b/Makefile
@@ -94,6 +94,10 @@ PHONY: test
 test:
 	GO111MODULE=on go test ./...
 
+PHONY: go-test
+go-test:
+	GO111MODULE=on go test ./...
+
 .PHONY: lint
 lint: FAKE
 	GO111MODULE=on GOFLAGS=-buildvcs=false golangci-lint run --timeout 5m


### PR DESCRIPTION
build_opt、test_commandを指定しないように変更します。
coreリポジトリとdatasource-apiリポジトリだけgo-testのルールがなくて共通化できなかったので、ルールを追加します。make testとやっていることは同じです。

## 観点
reusable workflow側でgo-testとtestを切り替えられるようにするのと、呼び出し側でgo-testを定義するののどちらが適切か。今回定義したreusable workflowはgoのbuildをしているので、goのtestは確実に行われるものとしてgo-testを呼び出側に定義するのが適切だと判断しました。