### PR TITLE
feat: add organization-editor preset role with scoped action pattern

### DIFF
--- a/pkg/server/organization/organization.go
+++ b/pkg/server/organization/organization.go
@@ -192,8 +192,8 @@ func (o *OrganizationService) createDefaultRole(ctx context.Context, ownerUserID
 	organizationAdmin := "organization-admin"
 	organizationEditor := "organization-editor"
 	organizationViewer := "organization-viewer"
-	viewerActionPtn := "get|list|put-alert-first-viewed-at"
-	editorActionPtn := viewerActionPtn + "|^(list-|get-|organization/update-|project/update-|project/tag-|project/untag-|organization-alert/.*|finding/.*|alert/.*|report/.*|aws/.*|google/.*|azure/.*|osint/.*|diagnosis/.*|code/.*|datasource/.*|ai/.*)"
+	viewerActionPtn := "list-|get-|put-alert-first-viewed-at"
+	editorActionPtn := viewerActionPtn + "|organization/update-|project/update-|project/tag-|project/untag-|organization-alert/.*|finding/.*|alert/.*|report/.*|aws/.*|google/.*|azure/.*|osint/.*|diagnosis/.*|code/.*|datasource/.*|ai/.*"
 
 	for name, actionPtn := range map[string]string{
 		organizationAdmin:  ".*",

--- a/pkg/server/organization/organization.go
+++ b/pkg/server/organization/organization.go
@@ -190,11 +190,14 @@ func (o *OrganizationService) removeOrganizationProject(ctx context.Context, org
 
 func (o *OrganizationService) createDefaultRole(ctx context.Context, ownerUserID, organizationID uint32) error {
 	organizationAdmin := "organization-admin"
+	organizationEditor := "organization-editor"
 	organizationViewer := "organization-viewer"
-	viewerActionPtn := "get|list|is-admin|put-alert-first-viewed-at"
+	viewerActionPtn := "get|list|put-alert-first-viewed-at"
+	editorActionPtn := viewerActionPtn + "|^(list-|get-|organization/update-|project/update-|project/tag-|project/untag-|organization-alert/.*|finding/.*|alert/.*|report/.*|aws/.*|google/.*|azure/.*|osint/.*|diagnosis/.*|code/.*|datasource/.*|ai/.*)"
 
 	for name, actionPtn := range map[string]string{
 		organizationAdmin:  ".*",
+		organizationEditor: editorActionPtn,
 		organizationViewer: viewerActionPtn,
 	} {
 		policy, err := o.orgIamClient.PutOrgPolicy(ctx, &org_iam.PutOrgPolicyRequest{

--- a/pkg/server/organization/organization.go
+++ b/pkg/server/organization/organization.go
@@ -192,8 +192,8 @@ func (o *OrganizationService) createDefaultRole(ctx context.Context, ownerUserID
 	organizationAdmin := "organization-admin"
 	organizationEditor := "organization-editor"
 	organizationViewer := "organization-viewer"
-	viewerActionPtn := "list-|get-|put-alert-first-viewed-at"
-	editorActionPtn := viewerActionPtn + "|organization/update-|project/update-|project/tag-|project/untag-|organization-alert/.*|finding/.*|alert/.*|report/.*|aws/.*|google/.*|azure/.*|osint/.*|diagnosis/.*|code/.*|datasource/.*|ai/.*"
+	viewerActionPtn := "get|list|is-admin|put-alert-first-viewed-at"
+	editorActionPtn := viewerActionPtn + "|organization/update-organization|project/update-project|project/tag-project|project/untag-project|organization-alert/.*|finding/.*|alert/.*|report/.*|aws/.*|google/.*|azure/.*|osint/.*|diagnosis/.*|code/.*|datasource/.*|ai/.*"
 
 	for name, actionPtn := range map[string]string{
 		organizationAdmin:  ".*",

--- a/pkg/server/organization/organization_test.go
+++ b/pkg/server/organization/organization_test.go
@@ -167,14 +167,14 @@ func TestCreateOrganization(t *testing.T) {
 				if c.wantErr && c.mockOrgIAMError != nil {
 					mockOrgIAM.On("PutOrgPolicy", test.RepeatMockAnything(2)...).Return(c.putPolicyResponse, c.mockOrgIAMError).Once()
 				} else {
-					mockOrgIAM.On("PutOrgPolicy", test.RepeatMockAnything(2)...).Return(c.putPolicyResponse, c.mockOrgIAMError).Times(2)
+					mockOrgIAM.On("PutOrgPolicy", test.RepeatMockAnything(2)...).Return(c.putPolicyResponse, c.mockOrgIAMError).Times(3)
 				}
 			}
 			if c.putRoleResponse != nil {
-				mockOrgIAM.On("PutOrgRole", test.RepeatMockAnything(2)...).Return(c.putRoleResponse, c.mockOrgIAMError).Times(2)
+				mockOrgIAM.On("PutOrgRole", test.RepeatMockAnything(2)...).Return(c.putRoleResponse, c.mockOrgIAMError).Times(3)
 			}
 			if c.attachPolicyResponse != nil {
-				mockOrgIAM.On("AttachOrgPolicy", test.RepeatMockAnything(2)...).Return(c.attachPolicyResponse, c.mockOrgIAMError).Times(2)
+				mockOrgIAM.On("AttachOrgPolicy", test.RepeatMockAnything(2)...).Return(c.attachPolicyResponse, c.mockOrgIAMError).Times(3)
 			}
 			if c.attachRoleResponse != nil {
 				mockOrgIAM.On("AttachOrgRole", test.RepeatMockAnything(2)...).Return(c.attachRoleResponse, c.mockOrgIAMError).Once()


### PR DESCRIPTION
Org Editorロールを追加します。
Viewerロールにis-adminアクションパターンは不要なのですが、後でput-alert-first-viewed-atとまとめて消すため、残しておきます。

## Org Editorの定義

Org Editorロールは以下の操作以外が可能です。

権限昇格できない
- Projectへの招待・Orgからの招待の追加、承認、削除ができない
- Org IAM、IAMの編集ができない

危険な操作ができない
- Project、Orgを削除できない

### 実装

ブラックリスト方式がGolangの正規表現だと使えないのでViewer権限に加えて、

- alert関連
- finding関連
- report関連
- データソース関連
- AI関連

を全て許可したものをEditor権限と定義しています。organizationとprojectについてはupdate-project、tag-project、untag-project、update-organizationなどのメタ情報の変更のみ許可します。